### PR TITLE
Add calendar entry ingredients CRUD

### DIFF
--- a/app/Http/Controllers/CalendarEntriesController.php
+++ b/app/Http/Controllers/CalendarEntriesController.php
@@ -35,7 +35,7 @@ class CalendarEntriesController extends Controller
     public function store(Request $request) {
 
         $params = $request->validate([
-            'type' => 'required|in:from_recipe,from_fast_food_store',
+            'type' => 'required|in:from_recipe,from_fast_food_store,from_ingredients',
             'meal_order' => 'integer|required',
             'date' => 'required|date',
         ]);
@@ -47,6 +47,7 @@ class CalendarEntriesController extends Controller
         return match ($params['type']) {
             'from_recipe' => $this->storeFromRecipe($request),
             'from_fast_food_store' => $this->storeFromFastFoodStore($request),
+            'from_ingredients' => $this->storeFromIngredients($request),
             default => ResponseUtils::generateErrorResponse('Invalid type'),
         };
 
@@ -67,7 +68,7 @@ class CalendarEntriesController extends Controller
     public function update(Request $request, CalendarEntry $calendarEntry) {
 
         $fields = $request->validate([
-            'type' => 'in:from_recipe',
+            'type' => 'in:from_recipe,from_fast_food_store,from_ingredients',
             'date' => 'date',
             'meal_order' => 'integer',
         ]);
@@ -84,6 +85,7 @@ class CalendarEntriesController extends Controller
         return match ($fields['type']) {
             'from_recipe' => $this->updateFromRecipe($request, $calendarEntry),
             'from_fast_food_store' => $this->updateFromFastFoodStore($request, $calendarEntry),
+            'from_ingredients' => $this->updateFromIngredients($request, $calendarEntry),
             default => ResponseUtils::generateErrorResponse('Invalid type'),
         };
     }
@@ -191,6 +193,63 @@ class CalendarEntriesController extends Controller
             'date' => $request['date'],
             'meal_order' => $request['meal_order'],
         ]);
+
+        return ResponseUtils::generateSuccessResponse($calendarEntry);
+    }
+
+    public function storeFromIngredients(Request $request) {
+        $fields = $request->validate([
+            'date' => 'required|date',
+            'meal_order' => 'integer|required',
+            'ingredients' => 'array',
+            'ingredients.*.ingredient_id' => 'required|exists:products,id',
+            'ingredients.*.unit_id' => 'required|exists:global_units,id',
+            'ingredients.*.amount' => 'numeric|required',
+        ]);
+
+        $user = $request->user();
+
+        $entry = $user->calendarEntries()->create([
+            'entry_type' => 'from_ingredients',
+            'calories' => 0,
+            'date' => $fields['date'],
+            'meal_order' => $fields['meal_order'],
+            'recipe_id' => 0,
+        ]);
+
+        if(isset($fields['ingredients'])) {
+            foreach ($fields['ingredients'] as $ing) {
+                $entry->calendarEntryIngredients()->create($ing);
+            }
+        }
+
+        return ResponseUtils::generateSuccessResponse($entry);
+    }
+
+    public function updateFromIngredients(Request $request, CalendarEntry $calendarEntry) {
+        $fields = $request->validate([
+            'date' => 'date',
+            'meal_order' => 'integer',
+            'ingredients' => 'array',
+            'ingredients.*.ingredient_id' => 'required|exists:products,id',
+            'ingredients.*.unit_id' => 'required|exists:global_units,id',
+            'ingredients.*.amount' => 'numeric|required',
+        ]);
+
+        $calendarEntry->update([
+            'entry_type' => 'from_ingredients',
+            'date' => $fields['date'] ?? $calendarEntry->date,
+            'meal_order' => $fields['meal_order'] ?? $calendarEntry->meal_order,
+            'recipe_id' => 0,
+            'fast_food_store_id' => null,
+        ]);
+
+        if(isset($fields['ingredients'])) {
+            $calendarEntry->calendarEntryIngredients()->delete();
+            foreach ($fields['ingredients'] as $ing) {
+                $calendarEntry->calendarEntryIngredients()->create($ing);
+            }
+        }
 
         return ResponseUtils::generateSuccessResponse($calendarEntry);
     }

--- a/app/Http/Controllers/CalendarEntryIngredientsController.php
+++ b/app/Http/Controllers/CalendarEntryIngredientsController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CalendarEntry;
+use App\Models\CalendarEntryIngredient;
+use App\Models\GlobalUnit;
+use App\Models\Product;
+use App\Utils\ResponseUtils;
+use Illuminate\Http\Request;
+
+class CalendarEntryIngredientsController extends Controller
+{
+    public function index(CalendarEntry $calendarEntry, Request $request)
+    {
+        return $calendarEntry->calendarEntryIngredients;
+    }
+
+    public function store(CalendarEntry $calendarEntry, Request $request)
+    {
+        $fields = $request->validate([
+            'ingredient_id' => 'required|exists:products,id',
+            'unit_id' => 'required|exists:global_units,id',
+            'amount' => 'required|numeric|min:0',
+        ]);
+
+        $calendarEntry->calendarEntryIngredients()->create($fields);
+        $entryIngredient = $calendarEntry->calendarEntryIngredients()->latest()->first();
+
+        return ResponseUtils::generateSuccessResponse($entryIngredient, 'OK', 201);
+    }
+
+    public function show(CalendarEntry $calendarEntry, CalendarEntryIngredient $calendarEntryIngredient, Request $request)
+    {
+        return ResponseUtils::generateSuccessResponse($calendarEntryIngredient);
+    }
+
+    public function update(CalendarEntry $calendarEntry, CalendarEntryIngredient $calendarEntryIngredient, Request $request)
+    {
+        $fields = $request->validate([
+            'ingredient_id' => 'exists:products,id',
+            'unit_id' => 'exists:global_units,id',
+            'amount' => 'numeric|min:0',
+        ]);
+
+        $calendarEntryIngredient->update($fields);
+
+        return ResponseUtils::generateSuccessResponse($calendarEntryIngredient);
+    }
+
+    public function destroy(CalendarEntry $calendarEntry, CalendarEntryIngredient $calendarEntryIngredient, Request $request)
+    {
+        $calendarEntryIngredient->delete();
+        return ResponseUtils::generateSuccessResponse('OK');
+    }
+}

--- a/app/Models/CalendarEntry.php
+++ b/app/Models/CalendarEntry.php
@@ -16,7 +16,7 @@ class CalendarEntry extends Model
         'fast_food_store_id'
     ];
 
-    protected $with = ['recipe', 'fastFoodStore', 'calendarEntryFastFoodMeals'];
+    protected $with = ['recipe', 'fastFoodStore', 'calendarEntryFastFoodMeals', 'calendarEntryIngredients'];
 
     public function recipe() {
         return $this->belongsTo(Recipe::class);
@@ -31,13 +31,21 @@ class CalendarEntry extends Model
         return $this->hasMany(CalendarEntryFastFoodMeal::class, 'calendar_entry_id', 'id');
     }
 
+    public function calendarEntryIngredients(): \Illuminate\Database\Eloquent\Relations\HasMany {
+        return $this->hasMany(CalendarEntryIngredient::class, 'calendar_entry_id', 'id');
+    }
+
     public function recalculate() {
         $calories = 0;
-        if ($this->entry_type == 'recipe') {
-            $calories = $this->recipe->calories;
-        } else {
+        if ($this->entry_type === 'from_recipe') {
+            $calories = $this->recipe->calories_per_serving;
+        } elseif ($this->entry_type === 'from_fast_food_store') {
             foreach ($this->calendarEntryFastFoodMeals as $meal) {
                 $calories += $meal->calories_per_ration * $meal->quantity;
+            }
+        } elseif ($this->entry_type === 'from_ingredients') {
+            foreach ($this->calendarEntryIngredients as $ing) {
+                $calories += $ing->calories;
             }
         }
         $this->calories = $calories;

--- a/app/Models/CalendarEntryIngredient.php
+++ b/app/Models/CalendarEntryIngredient.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CalendarEntryIngredient extends Model
+{
+    protected $fillable = [
+        'ingredient_id',
+        'unit_id',
+        'amount',
+        'calendar_entry_id',
+        'calories',
+    ];
+
+    protected $with = [
+        'ingredient',
+        'unit',
+    ];
+
+    public function ingredient(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(Product::class, 'ingredient_id');
+    }
+
+    public function unit(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(GlobalUnit::class, 'unit_id');
+    }
+
+    public function calendarEntry(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(CalendarEntry::class);
+    }
+
+    public function recalculate()
+    {
+        $product = $this->ingredient;
+        $unit = $this->unit;
+        if (!$product || !$unit) {
+            return;
+        }
+        $grams = $this->amount * $unit->converter;
+        $this->calories = $grams * ($product->nutrition_energy_kcal / 100);
+        $this->saveQuietly();
+    }
+
+    protected static function boot()
+    {
+        parent::boot();
+        static::creating(function ($model) {
+            $model->calories = 0;
+        });
+        static::created(function ($model) {
+            $model->recalculate();
+            $model->calendarEntry->recalculate();
+        });
+        static::updated(function ($model) {
+            $model->recalculate();
+            $model->calendarEntry->recalculate();
+        });
+        static::deleted(function ($model) {
+            $model->calendarEntry->recalculate();
+        });
+    }
+}

--- a/database/migrations/2024_12_30_000000_create_calendar_entry_ingredients_table.php
+++ b/database/migrations/2024_12_30_000000_create_calendar_entry_ingredients_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('calendar_entry_ingredients', function (Blueprint $table) {
+            $table->id();
+            $table->integer('ingredient_id');
+            $table->integer('unit_id');
+            $table->decimal('amount');
+            $table->integer('calendar_entry_id');
+            $table->decimal('calories')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('calendar_entry_ingredients');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\AIController;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\CalendarEntriesController;
 use App\Http\Controllers\CalendarEntryFastFoodMealsController;
+use App\Http\Controllers\CalendarEntryIngredientsController;
 use App\Http\Controllers\FastFoodMealsController;
 use App\Http\Controllers\FastFoodMealSetMealsController;
 use App\Http\Controllers\FastFoodMealSetsController;
@@ -197,6 +198,15 @@ Route::middleware('auth:sanctum')->group(fn() => [
                 Route::get('/{calendarEntryFastFoodMeal}',[CalendarEntryFastFoodMealsController::class,'show']),
                 Route::match(['put','patch'],'/{calendarEntryFastFoodMeal}',[CalendarEntryFastFoodMealsController::class,'update']),
                 Route::delete('/{calendarEntryFastFoodMeal}',[CalendarEntryFastFoodMealsController::class,'destroy']),
+            ]),
+
+        Route::prefix('/{calendarEntry}/ingredient')
+            ->group(fn() => [
+                Route::get('/',[CalendarEntryIngredientsController::class,'index']),
+                Route::post('/',[CalendarEntryIngredientsController::class,'store']),
+                Route::get('/{calendarEntryIngredient}',[CalendarEntryIngredientsController::class,'show']),
+                Route::match(['put','patch'],'/{calendarEntryIngredient}',[CalendarEntryIngredientsController::class,'update']),
+                Route::delete('/{calendarEntryIngredient}',[CalendarEntryIngredientsController::class,'destroy']),
             ]),
 
     ]),


### PR DESCRIPTION
## Summary
- support CRUD for calendar entry ingredients
- wire new endpoints under `/calendar-entry/{calendarEntry}/ingredient`
- recalc calendar entry calories based on ingredient entries

## Testing
- `phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_685932332c888323ae625c7c7f1cb6e5