### PR TITLE
Add quick and ingredient calendar entries

### DIFF
--- a/backend/app/Http/Controllers/CalendarEntriesController.php
+++ b/backend/app/Http/Controllers/CalendarEntriesController.php
@@ -35,7 +35,7 @@ class CalendarEntriesController extends Controller
     public function store(Request $request) {
 
         $params = $request->validate([
-            'type' => 'required|in:from_recipe,from_fast_food_store,from_ingredients',
+            'type' => 'required|in:from_recipe,from_fast_food_store,from_ingredients,quick_entry',
             'meal_order' => 'integer|required',
             'date' => 'required|date',
         ]);
@@ -48,6 +48,7 @@ class CalendarEntriesController extends Controller
             'from_recipe' => $this->storeFromRecipe($request),
             'from_fast_food_store' => $this->storeFromFastFoodStore($request),
             'from_ingredients' => $this->storeFromIngredients($request),
+            'quick_entry' => $this->storeFromQuickEntry($request),
             default => ResponseUtils::generateErrorResponse('Invalid type'),
         };
 
@@ -68,7 +69,7 @@ class CalendarEntriesController extends Controller
     public function update(Request $request, CalendarEntry $calendarEntry) {
 
         $fields = $request->validate([
-            'type' => 'in:from_recipe,from_fast_food_store,from_ingredients',
+            'type' => 'in:from_recipe,from_fast_food_store,from_ingredients,quick_entry',
             'date' => 'date',
             'meal_order' => 'integer',
         ]);
@@ -86,6 +87,7 @@ class CalendarEntriesController extends Controller
             'from_recipe' => $this->updateFromRecipe($request, $calendarEntry),
             'from_fast_food_store' => $this->updateFromFastFoodStore($request, $calendarEntry),
             'from_ingredients' => $this->updateFromIngredients($request, $calendarEntry),
+            'quick_entry' => $this->updateFromQuickEntry($request, $calendarEntry),
             default => ResponseUtils::generateErrorResponse('Invalid type'),
         };
     }
@@ -249,6 +251,61 @@ class CalendarEntriesController extends Controller
             foreach ($fields['ingredients'] as $ing) {
                 $calendarEntry->calendarEntryIngredients()->create($ing);
             }
+        }
+
+        return ResponseUtils::generateSuccessResponse($calendarEntry);
+    }
+
+    public function storeFromQuickEntry(Request $request) {
+        $fields = $request->validate([
+            'date' => 'required|date',
+            'meal_order' => 'required|integer',
+            'name' => 'required|string',
+            'calories' => 'required|numeric',
+        ]);
+
+        $user = $request->user();
+
+        $entry = $user->calendarEntries()->create([
+            'entry_type' => 'quick_entry',
+            'calories' => $fields['calories'],
+            'date' => $fields['date'],
+            'meal_order' => $fields['meal_order'],
+            'recipe_id' => 0,
+            'fast_food_store_id' => null,
+        ]);
+
+        $entry->calendarEntryQuickEntries()->create([
+            'name' => $fields['name'],
+            'calories' => $fields['calories'],
+        ]);
+
+        return ResponseUtils::generateSuccessResponse($entry);
+    }
+
+    public function updateFromQuickEntry(Request $request, CalendarEntry $calendarEntry) {
+        $fields = $request->validate([
+            'date' => 'date',
+            'meal_order' => 'integer',
+            'name' => 'string',
+            'calories' => 'numeric',
+        ]);
+
+        $calendarEntry->update([
+            'entry_type' => 'quick_entry',
+            'date' => $fields['date'] ?? $calendarEntry->date,
+            'meal_order' => $fields['meal_order'] ?? $calendarEntry->meal_order,
+            'calories' => $fields['calories'] ?? $calendarEntry->calories,
+            'recipe_id' => 0,
+            'fast_food_store_id' => null,
+        ]);
+
+        $quick = $calendarEntry->calendarEntryQuickEntries()->first();
+        if($quick){
+            $quick->update([
+                'name' => $fields['name'] ?? $quick->name,
+                'calories' => $fields['calories'] ?? $quick->calories,
+            ]);
         }
 
         return ResponseUtils::generateSuccessResponse($calendarEntry);

--- a/backend/app/Http/Controllers/CalendarEntryQuickEntriesController.php
+++ b/backend/app/Http/Controllers/CalendarEntryQuickEntriesController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CalendarEntry;
+use App\Models\CalendarEntryQuickEntry;
+use App\Utils\ResponseUtils;
+use Illuminate\Http\Request;
+
+class CalendarEntryQuickEntriesController extends Controller
+{
+    public function index(CalendarEntry $calendarEntry, Request $request)
+    {
+        return $calendarEntry->calendarEntryQuickEntries;
+    }
+
+    public function store(CalendarEntry $calendarEntry, Request $request)
+    {
+        $fields = $request->validate([
+            'name' => 'required|string',
+            'calories' => 'required|numeric'
+        ]);
+
+        $calendarEntry->calendarEntryQuickEntries()->create($fields);
+        $entry = $calendarEntry->calendarEntryQuickEntries()->latest()->first();
+        return ResponseUtils::generateSuccessResponse($entry, 'OK', 201);
+    }
+
+    public function show(CalendarEntry $calendarEntry, CalendarEntryQuickEntry $calendarEntryQuickEntry, Request $request)
+    {
+        return ResponseUtils::generateSuccessResponse($calendarEntryQuickEntry);
+    }
+
+    public function update(CalendarEntry $calendarEntry, CalendarEntryQuickEntry $calendarEntryQuickEntry, Request $request)
+    {
+        $fields = $request->validate([
+            'name' => 'string',
+            'calories' => 'numeric'
+        ]);
+        $calendarEntryQuickEntry->update($fields);
+        return ResponseUtils::generateSuccessResponse($calendarEntryQuickEntry);
+    }
+
+    public function destroy(CalendarEntry $calendarEntry, CalendarEntryQuickEntry $calendarEntryQuickEntry, Request $request)
+    {
+        $calendarEntryQuickEntry->delete();
+        return ResponseUtils::generateSuccessResponse('OK');
+    }
+}

--- a/backend/app/Models/CalendarEntry.php
+++ b/backend/app/Models/CalendarEntry.php
@@ -16,7 +16,7 @@ class CalendarEntry extends Model
         'fast_food_store_id'
     ];
 
-    protected $with = ['recipe', 'fastFoodStore', 'calendarEntryFastFoodMeals', 'calendarEntryIngredients'];
+    protected $with = ["recipe", "fastFoodStore", "calendarEntryFastFoodMeals", "calendarEntryIngredients", "calendarEntryQuickEntries"];
 
     public function recipe() {
         return $this->belongsTo(Recipe::class);
@@ -35,6 +35,10 @@ class CalendarEntry extends Model
         return $this->hasMany(CalendarEntryIngredient::class, 'calendar_entry_id', 'id');
     }
 
+    public function calendarEntryQuickEntries(): \Illuminate\Database\Eloquent\Relations\HasMany {
+        return $this->hasMany(CalendarEntryQuickEntry::class, 'calendar_entry_id', 'id');
+    }
+
     public function recalculate() {
         $calories = 0;
         if ($this->entry_type === 'from_recipe') {
@@ -46,6 +50,10 @@ class CalendarEntry extends Model
         } elseif ($this->entry_type === 'from_ingredients') {
             foreach ($this->calendarEntryIngredients as $ing) {
                 $calories += $ing->calories;
+            }
+        } elseif ($this->entry_type === 'quick_entry') {
+            foreach ($this->calendarEntryQuickEntries as $quick) {
+                $calories += $quick->calories;
             }
         }
         $this->calories = $calories;

--- a/backend/app/Models/CalendarEntryQuickEntry.php
+++ b/backend/app/Models/CalendarEntryQuickEntry.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CalendarEntryQuickEntry extends Model
+{
+    protected $fillable = [
+        'name',
+        'calories',
+        'calendar_entry_id'
+    ];
+
+    public function calendarEntry()
+    {
+        return $this->belongsTo(CalendarEntry::class);
+    }
+
+    protected static function boot()
+    {
+        parent::boot();
+        static::created(function($item){
+            $item->calendarEntry->recalculate();
+        });
+        static::updated(function($item){
+            $item->calendarEntry->recalculate();
+        });
+        static::deleted(function($item){
+            $item->calendarEntry->recalculate();
+        });
+    }
+}

--- a/backend/database/migrations/2024_12_31_000001_create_calendar_entry_quick_entries_table.php
+++ b/backend/database/migrations/2024_12_31_000001_create_calendar_entry_quick_entries_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('calendar_entry_quick_entries', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->decimal('calories');
+            $table->integer('calendar_entry_id');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('calendar_entry_quick_entries');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\CalendarEntriesController;
 use App\Http\Controllers\CalendarEntryFastFoodMealsController;
 use App\Http\Controllers\CalendarEntryIngredientsController;
+use App\Http\Controllers\CalendarEntryQuickEntriesController;
 use App\Http\Controllers\FastFoodMealsController;
 use App\Http\Controllers\FastFoodMealSetMealsController;
 use App\Http\Controllers\FastFoodMealSetsController;
@@ -207,6 +208,15 @@ Route::middleware('auth:sanctum')->group(fn() => [
                 Route::get('/{calendarEntryIngredient}',[CalendarEntryIngredientsController::class,'show']),
                 Route::match(['put','patch'],'/{calendarEntryIngredient}',[CalendarEntryIngredientsController::class,'update']),
                 Route::delete('/{calendarEntryIngredient}',[CalendarEntryIngredientsController::class,'destroy']),
+            ]),
+
+        Route::prefix('/{calendarEntry}/quick-entry')
+            ->group(fn() => [
+                Route::get('/',[CalendarEntryQuickEntriesController::class,'index']),
+                Route::post('/',[CalendarEntryQuickEntriesController::class,'store']),
+                Route::get('/{calendarEntryQuickEntry}',[CalendarEntryQuickEntriesController::class,'show']),
+                Route::match(['put','patch'],'/{calendarEntryQuickEntry}',[CalendarEntryQuickEntriesController::class,'update']),
+                Route::delete('/{calendarEntryQuickEntry}',[CalendarEntryQuickEntriesController::class,'destroy']),
             ]),
 
     ]),

--- a/frontend/src/API/CalendarEntryIngredientsAPI.js
+++ b/frontend/src/API/CalendarEntryIngredientsAPI.js
@@ -1,0 +1,27 @@
+import RequestUtils from "@/Utils/RequestUtils";
+
+export default class CalendarEntryIngredientsAPI {
+    static async getAll(calendarEntryId) {
+        return await RequestUtils.apiGet(`/api/calendar-entry/${calendarEntryId}/ingredient`);
+    }
+
+    static async get(calendarEntryId, id) {
+        return await RequestUtils.apiGet(`/api/calendar-entry/${calendarEntryId}/ingredient/${id}`);
+    }
+
+    static async create(calendarEntryId, data) {
+        const result = await RequestUtils.apiPost(`/api/calendar-entry/${calendarEntryId}/ingredient`, data);
+        if(result.status >= 300) {
+            throw new Error('CalendarEntryIngredientsAPI.create() failed, status: ' + result.status);
+        }
+        return result;
+    }
+
+    static async update(calendarEntryId, id, data) {
+        return await RequestUtils.apiPut(`/api/calendar-entry/${calendarEntryId}/ingredient/${id}`, data);
+    }
+
+    static async delete(calendarEntryId, id) {
+        return await RequestUtils.apiDelete(`/api/calendar-entry/${calendarEntryId}/ingredient/${id}`);
+    }
+}

--- a/frontend/src/API/CalendarEntryQuickEntriesAPI.js
+++ b/frontend/src/API/CalendarEntryQuickEntriesAPI.js
@@ -1,0 +1,27 @@
+import RequestUtils from "@/Utils/RequestUtils";
+
+export default class CalendarEntryQuickEntriesAPI {
+    static async getAll(calendarEntryId) {
+        return await RequestUtils.apiGet(`/api/calendar-entry/${calendarEntryId}/quick-entry`);
+    }
+
+    static async get(calendarEntryId, id) {
+        return await RequestUtils.apiGet(`/api/calendar-entry/${calendarEntryId}/quick-entry/${id}`);
+    }
+
+    static async create(calendarEntryId, data) {
+        const result = await RequestUtils.apiPost(`/api/calendar-entry/${calendarEntryId}/quick-entry`, data);
+        if(result.status >= 300) {
+            throw new Error('CalendarEntryQuickEntriesAPI.create() failed, status: ' + result.status);
+        }
+        return result;
+    }
+
+    static async update(calendarEntryId, id, data) {
+        return await RequestUtils.apiPut(`/api/calendar-entry/${calendarEntryId}/quick-entry/${id}`, data);
+    }
+
+    static async delete(calendarEntryId, id) {
+        return await RequestUtils.apiDelete(`/api/calendar-entry/${calendarEntryId}/quick-entry/${id}`);
+    }
+}

--- a/frontend/src/Components/CalendarMealEntry/CalendarIngredientsEntry.jsx
+++ b/frontend/src/Components/CalendarMealEntry/CalendarIngredientsEntry.jsx
@@ -1,0 +1,77 @@
+import styled from "styled-components";
+import {Checkbox, IconButton} from "@mui/material";
+import {DeleteForever, Edit} from "@mui/icons-material";
+
+const Container = styled.div`
+  height: 160px;
+  margin-bottom: 20px;
+  border-radius: 20px;
+  background-color: white;
+  position: relative;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+const MealName = styled.p`
+    padding: 2px 20px 2px 8px;
+    background-color: white;
+    display: block;
+    width: fit-content;
+    border-bottom-right-radius: 20px;
+    color: gray;
+`;
+
+const RecipeName = styled.p`
+    padding: 2px 10px 2px 8px;
+    background-color: white;
+    display: block;
+    width: fit-content;
+    border-top-right-radius: 20px;
+    color: gray;
+    max-width: 80%;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    position: absolute;
+    bottom: 0;
+`;
+
+const RecipeEditButton = styled.div`
+position: absolute;
+  top: -6px;
+  right: 24px;
+  padding: 5px;
+`;
+
+const RecipeDeleteButton = styled.div`
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  padding: 5px;
+`;
+
+const CalendarIngredientsEntry = ({meal, mealName, onClick, onEdit, selectMode, onCheck, onDelete}) => {
+    const handleClick = (e) => {
+        if(e.target.tagName !== 'BUTTON'
+            && e.target.tagName !== 'svg'
+            && e.target.tagName !== 'path'
+            && e.target.tagName !== 'INPUT')
+        {
+            onClick();
+        }
+    }
+
+    return <Container onClick={handleClick}>
+        <MealName>{mealName}</MealName>
+        <RecipeName>Składników: {meal.calendar_entry_ingredients?.length}</RecipeName>
+        <RecipeEditButton>
+            {!selectMode && <IconButton onClick={onEdit}><Edit sx={{color:'#FACC2C', backgroundColor:'white',borderRadius:'22px',padding:'2px'}} /></IconButton>}
+        </RecipeEditButton>
+        <RecipeDeleteButton>
+            {selectMode ? <Checkbox sx={{color:'#FACC2C'}} checked={meal.selected} onChange={() => onCheck(meal.id)} /> : <IconButton onClick={() => onDelete(meal.id)}><DeleteForever sx={{color:'red', backgroundColor:'white',borderRadius:'22px',padding:'2px'}} /></IconButton>}
+        </RecipeDeleteButton>
+    </Container>
+}
+
+export default CalendarIngredientsEntry;

--- a/frontend/src/Components/CalendarMealEntry/CalendarQuickEntry.jsx
+++ b/frontend/src/Components/CalendarMealEntry/CalendarQuickEntry.jsx
@@ -1,0 +1,79 @@
+import styled from "styled-components";
+import {Checkbox, IconButton} from "@mui/material";
+import {DeleteForever, Edit} from "@mui/icons-material";
+
+const Container = styled.div`
+  height: 160px;
+  margin-bottom: 20px;
+  border-radius: 20px;
+  background-color: white;
+  position: relative;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+const MealName = styled.p`
+    padding: 2px 20px 2px 8px;
+    background-color: white;
+    display: block;
+    width: fit-content;
+    border-bottom-right-radius: 20px;
+    color: gray;
+`;
+
+const RecipeName = styled.p`
+    padding: 2px 10px 2px 8px;
+    background-color: white;
+    display: block;
+    width: fit-content;
+    border-top-right-radius: 20px;
+    color: gray;
+    max-width: 80%;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    position: absolute;
+    bottom: 0;
+`;
+
+const RecipeEditButton = styled.div`
+position: absolute;
+  top: -6px;
+  right: 24px;
+  padding: 5px;
+`;
+
+const RecipeDeleteButton = styled.div`
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  padding: 5px;
+`;
+
+const CalendarQuickEntry = ({meal, mealName, onClick, onEdit, selectMode, onCheck, onDelete}) => {
+    const handleClick = (e) => {
+        if(e.target.tagName !== 'BUTTON'
+            && e.target.tagName !== 'svg'
+            && e.target.tagName !== 'path'
+            && e.target.tagName !== 'INPUT')
+        {
+            onClick();
+        }
+    }
+
+    const item = meal.calendar_entry_quick_entries?.[0];
+
+    return <Container onClick={handleClick}>
+        <MealName>{mealName}</MealName>
+        <RecipeName>{item?.name}</RecipeName>
+        <RecipeEditButton>
+            {!selectMode && <IconButton onClick={onEdit}><Edit sx={{color:'#FACC2C', backgroundColor:'white',borderRadius:'22px',padding:'2px'}} /></IconButton>}
+        </RecipeEditButton>
+        <RecipeDeleteButton>
+            {selectMode ? <Checkbox sx={{color:'#FACC2C'}} checked={meal.selected} onChange={() => onCheck(meal.id)} /> : <IconButton onClick={() => onDelete(meal.id)}><DeleteForever sx={{color:'red', backgroundColor:'white',borderRadius:'22px',padding:'2px'}} /></IconButton>}
+        </RecipeDeleteButton>
+    </Container>
+}
+
+export default CalendarQuickEntry;

--- a/frontend/src/Dialogs/CalendarEntryFromIngredientsCEDialog.jsx
+++ b/frontend/src/Dialogs/CalendarEntryFromIngredientsCEDialog.jsx
@@ -23,18 +23,18 @@ const CalendarEntryFromIngredientsCEDialog = ({open, onClose, onSelect}) => {
             return;
         }
 
-        setItems([...items,{product, quantity:1, unitId: product?.units?.[0]?.id || 0}]);
+        setItems([...items,{product, amount:1, unitId: product?.units?.[0]?.id || 0}]);
     };
 
-    const updateQuantity = (id,val) => setItems(items.map(it=>it.product.id===id?{...it,quantity:val}:it));
+    const updateQuantity = (id,val) => setItems(items.map(it=>it.product.id===id?{...it,amount:val}:it));
     const updateUnit = (id,val) => setItems(items.map(it=>it.product.id===id?{...it,unitId:val}:it));
     const removeItem = (id) => setItems(items.filter(it=>it.product.id!==id));
 
     const handleSave = () => {
         const data = items.map(it=>({
-            product_id: it.product.id,
+            ingredient_id: it.product.id,
             unit_id: it.unitId,
-            quantity: it.quantity
+            amount: it.amount
         }));
         console.log({ingredients: data});
         if(onSelect) onSelect({ingredients: data});
@@ -73,7 +73,7 @@ const CalendarEntryFromIngredientsCEDialog = ({open, onClose, onSelect}) => {
                                         ))}
                                     </Select>
                                 </FormControl>
-                                <NumberInput withoutButtons={true} value={item.quantity} min={0} max={1000} onChange={(e, val) => updateQuantity(item.product.id, val)} />
+                                <NumberInput withoutButtons={true} value={item.amount} min={0} max={1000} onChange={(e, val) => updateQuantity(item.product.id, val)} />
                                 <IconButton onClick={() => removeItem(item.product.id)}><Delete /></IconButton>
                             </Box>
                         </Box>

--- a/frontend/src/Dialogs/IngredientsEntryViewDialog.jsx
+++ b/frontend/src/Dialogs/IngredientsEntryViewDialog.jsx
@@ -1,0 +1,34 @@
+import {useEffect, useState} from "react";
+import {Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography} from "@mui/material";
+import CalendarEntriesAPI from "@/API/CalendarEntriesAPI";
+
+const IngredientsEntryViewDialog = ({open, onClose, id}) => {
+    const [entry,setEntry] = useState(null);
+
+    const load = async () => {
+        const {data} = await CalendarEntriesAPI.get(id);
+        setEntry(data.data);
+    }
+
+    useEffect(() => { if(open && id) load(); }, [open,id]);
+
+    return (
+        <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+            <DialogTitle>Szczegóły</DialogTitle>
+            <DialogContent>
+                <Typography variant="h6">Składniki:</Typography>
+                <ul style={{marginLeft:20}}>
+                    {entry?.calendar_entry_ingredients?.map(it => (
+                        <li key={it.id}>{it.ingredient.name} - {it.amount}{it.unit.name} ({Math.round(it.calories)} kcal)</li>
+                    ))}
+                </ul>
+                <Typography variant="h6">Podsumowanie: {Math.round(entry?.calories||0)} kcal</Typography>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose}>Zamknij</Button>
+            </DialogActions>
+        </Dialog>
+    );
+}
+
+export default IngredientsEntryViewDialog;

--- a/frontend/src/Dialogs/QuickEntryViewDialog.jsx
+++ b/frontend/src/Dialogs/QuickEntryViewDialog.jsx
@@ -1,0 +1,31 @@
+import {useEffect, useState} from "react";
+import {Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography} from "@mui/material";
+import CalendarEntriesAPI from "@/API/CalendarEntriesAPI";
+
+const QuickEntryViewDialog = ({open, onClose, id}) => {
+    const [entry,setEntry] = useState(null);
+
+    const load = async () => {
+        const {data} = await CalendarEntriesAPI.get(id);
+        setEntry(data.data);
+    }
+
+    useEffect(() => { if(open && id) load(); }, [open,id]);
+
+    const item = entry?.calendar_entry_quick_entries?.[0];
+
+    return (
+        <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+            <DialogTitle>Szczegóły</DialogTitle>
+            <DialogContent>
+                <Typography variant="h6">{item?.name}</Typography>
+                <Typography variant="h6">Kalorie: {item?.calories}</Typography>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose}>Zamknij</Button>
+            </DialogActions>
+        </Dialog>
+    );
+}
+
+export default QuickEntryViewDialog;

--- a/frontend/src/Views/Dashboard/CalendarView.jsx
+++ b/frontend/src/Views/Dashboard/CalendarView.jsx
@@ -23,6 +23,8 @@ import {refreshUser} from "@/Store/Reducers/AuthReducer";
 import store from "@/Store/store";
 import CalendarMealPlaceholder from "@/Components/CalendarMealEntry/CalendarMealPlaceholder";
 import CalendarMealRecipe from "@/Components/CalendarMealEntry/CalendarMealRecipe";
+import CalendarIngredientsEntry from "@/Components/CalendarMealEntry/CalendarIngredientsEntry";
+import CalendarQuickEntry from "@/Components/CalendarMealEntry/CalendarQuickEntry";
 import RecipeSelectorDialog from "@/Dialogs/RecipeSelectorDialog";
 import SourceSelectDialog from "@/Dialogs/SourceSelectDialog";
 import {Swiper, SwiperSlide} from "swiper/react";
@@ -38,7 +40,10 @@ import ConfirmDialog from "@/Dialogs/ConfirmDialog";
 import CalendarFastFoodRecipe from "@/Components/CalendarMealEntry/CalendarFastFoodRecipe";
 import CalendarEntryFromFastFoodCEDialog from "@/Dialogs/CalendarEntryFromFastFoodCEDialog";
 import CalendarEntryFastFoodAPI from "@/API/CalendarEntryFastFoodAPI";
+import CalendarEntryQuickEntriesAPI from "@/API/CalendarEntryQuickEntriesAPI";
 import FastFoodEntryViewDialog from "@/Dialogs/FastFoodEntryViewDialog";
+import IngredientsEntryViewDialog from "@/Dialogs/IngredientsEntryViewDialog";
+import QuickEntryViewDialog from "@/Dialogs/QuickEntryViewDialog";
 import TrainingsAPI from "@/API/TrainingsAPI";
 import CalendarQuickAddDialog from "@/Dialogs/CalendarQuickAddDialog";
 
@@ -141,7 +146,31 @@ const GetMealFromData = ({date,mealNo,meals,title, onClick, onEdit,selectMode, o
                     selectMode={selectMode}
                     editMode={editMode}
                     mealName={title}
-                    onClick={() => onClick(meal.id)}
+                    onClick={() => onClick(meal.id,'from_fast_food_store')}
+                    onEdit={onEdit}
+                    onCheck={onCheck}
+                />
+            }
+            case "from_ingredients":{
+                return <CalendarIngredientsEntry
+                    meal={meal}
+                    onDelete={onDelete}
+                    selectMode={selectMode}
+                    editMode={editMode}
+                    mealName={title}
+                    onClick={() => onClick(meal.id,'from_ingredients')}
+                    onEdit={onEdit}
+                    onCheck={onCheck}
+                />
+            }
+            case "quick_entry":{
+                return <CalendarQuickEntry
+                    meal={meal}
+                    onDelete={onDelete}
+                    selectMode={selectMode}
+                    editMode={editMode}
+                    mealName={title}
+                    onClick={() => onClick(meal.id,'quick_entry')}
                     onEdit={onEdit}
                     onCheck={onCheck}
                 />
@@ -188,7 +217,9 @@ const CalendarView = () => {
     const [openSourceSelectDialog,setOpenSourceSelectDialog] = useState(false);
     const [selectedSource,setSelectedSource] = useState(null);
     const [selectedEditData,setSelectedEditData] = useState(null);
-    const [selectedViewId,setSelectedViewId] = useState(null);
+    const [selectedFastFoodViewId,setSelectedFastFoodViewId] = useState(null);
+    const [selectedIngredientsViewId,setSelectedIngredientsViewId] = useState(null);
+    const [selectedQuickViewId,setSelectedQuickViewId] = useState(null);
 
     const [selsectedListIdOpen,setSelectedListIdOpen] = useState(false);
     const [selectedMode,setSelectedMode] = useState('read');
@@ -263,7 +294,19 @@ const CalendarView = () => {
     }
 
     const selectIngredients = (data) => {
-        console.log('INGREDIENTS', data);
+        toast.promise(
+            CalendarEntriesAPI.create({
+                type: 'from_ingredients',
+                date: selectedEditData.date,
+                meal_order: selectedEditData.mealNo,
+                ingredients: data.ingredients
+            }),
+            {
+                loading: 'Dodawanie... ',
+                success: 'Dodano składniki',
+                error: 'Nie udało się dodać'
+            }
+        ).then(load);
         handleCloseSourceInputDialog();
     }
 
@@ -310,8 +353,10 @@ const CalendarView = () => {
                         mealNo={index}
                         meals={entries}
                         title={title}
-                        onClick={(id) => {
-                            setSelectedViewId(id)
+                        onClick={(id,type) => {
+                            if(type === 'from_fast_food_store') setSelectedFastFoodViewId(id);
+                            if(type === 'from_ingredients') setSelectedIngredientsViewId(id);
+                            if(type === 'quick_entry') setSelectedQuickViewId(id);
                         }}
                         onEdit={ () => {
                             setOpenSourceSelectDialog(true);
@@ -327,7 +372,7 @@ const CalendarView = () => {
         </DateContainer>
     });
 
-    const selectFastFood = async (fastFood) => {
+const selectFastFood = async (fastFood) => {
 
         if(fastFood.meals.length === 0){
             handleCloseSourceInputDialog();
@@ -358,6 +403,25 @@ const CalendarView = () => {
         handleCloseSourceInputDialog();
         load();
 
+    }
+
+    const selectQuick = async (data) => {
+        const res = await toast.promise(
+            CalendarEntriesAPI.create({
+                type: 'quick_entry',
+                date: selectedEditData.date,
+                meal_order: selectedEditData.mealNo
+            }),
+            {
+                loading: 'Dodawanie...',
+                success: 'Dodano wpis',
+                error: 'Błąd podczas dodawania'
+            }
+        );
+        const entryId = res.data.data.id;
+        await CalendarEntryQuickEntriesAPI.create(entryId, data);
+        handleCloseSourceInputDialog();
+        load();
     }
 
     return <Container>
@@ -423,10 +487,19 @@ const CalendarView = () => {
             onSelect={selectFastFood}
         />
         <FastFoodEntryViewDialog
-            open={ selectedViewId !== null}
-            onClose={handleCloseSourceInputDialog}
-            id={selectedViewId}
-            onClose={() => setSelectedViewId(null)}
+            open={ selectedFastFoodViewId !== null}
+            onClose={() => setSelectedFastFoodViewId(null)}
+            id={selectedFastFoodViewId}
+        />
+        <IngredientsEntryViewDialog
+            open={selectedIngredientsViewId !== null}
+            onClose={() => setSelectedIngredientsViewId(null)}
+            id={selectedIngredientsViewId}
+        />
+        <QuickEntryViewDialog
+            open={selectedQuickViewId !== null}
+            onClose={() => setSelectedQuickViewId(null)}
+            id={selectedQuickViewId}
         />
         <RecipeSelectorDialog
             open={selectedSource === 'recipe'}
@@ -436,6 +509,7 @@ const CalendarView = () => {
         <CalendarQuickAddDialog
             open={selectedSource === 'quick'}
             onClose={handleCloseSourceInputDialog}
+            onSave={selectQuick}
         />
         <div style={!isMobile && {
             display: 'flex',


### PR DESCRIPTION
## Summary
- create quick entry backend model, controller, migration
- expose quick entry API routes
- update calendar entry model and controller for quick/ingredient entries
- add frontend APIs and components for ingredients and quick entries
- extend calendar view to handle and display these entries with detail dialogs

## Testing
- `npm test --silent` *(fails: craco not found)*
- `./vendor/bin/phpunit --stop-on-failure` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a781c3d408323b4490b0c03bedbb6