### PR TITLE
Add default shopping list feature

### DIFF
--- a/backend/app/Http/Controllers/ShoppingListsController.php
+++ b/backend/app/Http/Controllers/ShoppingListsController.php
@@ -110,6 +110,7 @@ class ShoppingListsController extends Controller {
         $fields = $request->validate([
             'name' => 'required|string',
             'type' => 'string|in:default,grouped',
+            'default' => 'boolean',
         ]);
 
          $newShoppingList = ShoppingList::create([
@@ -132,6 +133,7 @@ class ShoppingListsController extends Controller {
         $fields = $request->validate([
             'name' => 'string',
             'type' => 'string|in:default,grouped',
+            'default' => 'boolean',
         ]);
 
         $shoppingList->update($fields);
@@ -143,5 +145,14 @@ class ShoppingListsController extends Controller {
     public function destroy(ShoppingList $shoppingList) {
         $shoppingList->delete();
         return ResponseUtils::generateSuccessResponse();
+    }
+
+    public function setDefault(ShoppingList $shoppingList, Request $request) {
+        $this->authorize('update', $shoppingList);
+
+        $shoppingList->update(['default' => true]);
+        $shoppingList = $shoppingList->refresh();
+
+        return ResponseUtils::generateSuccessResponse($shoppingList);
     }
 }

--- a/backend/app/Models/ShoppingList.php
+++ b/backend/app/Models/ShoppingList.php
@@ -9,11 +9,34 @@ class ShoppingList extends Model {
         'name',
         'user_id',
         'type',
+        'default',
+    ];
+
+    protected $casts = [
+        'default' => 'boolean',
     ];
 
     protected $with = [
         'entries',
     ];
+
+    protected static function boot() {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if($model->default) {
+                ShoppingList::where('user_id', $model->user_id)
+                    ->update(['default' => false]);
+            }
+        });
+
+        static::updating(function ($model) {
+            if($model->default) {
+                ShoppingList::where('user_id', $model->user_id)
+                    ->update(['default' => false]);
+            }
+        });
+    }
 
 
     function entries(): \Illuminate\Database\Eloquent\Relations\HasMany {

--- a/backend/database/migrations/2025_06_24_000000_add_default_flag_to_shopping_lists_table.php
+++ b/backend/database/migrations/2025_06_24_000000_add_default_flag_to_shopping_lists_table.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void {
+        Schema::table('shopping_lists', function (Blueprint $table) {
+            $table->boolean('default')->default(false);
+        });
+    }
+
+    public function down(): void {
+        Schema::table('shopping_lists', function (Blueprint $table) {
+            $table->dropColumn('default');
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -79,6 +79,7 @@ Route::middleware('auth:sanctum')->group(fn() => [
             [ShoppingListsController::class,'insertCalendarEntries']),
         Route::get('/{shoppingList}',[ShoppingListsController::class,'show']),
         Route::match(['put','patch'],'/{shoppingList}',[ShoppingListsController::class,'update']),
+        Route::match(['put','patch'],'/{shoppingList}/default',[ShoppingListsController::class,'setDefault']),
         Route::delete('/{shoppingList}',[ShoppingListsController::class,'destroy']),
 
 

--- a/frontend/src/API/ShoppingListsAPI.js
+++ b/frontend/src/API/ShoppingListsAPI.js
@@ -28,6 +28,10 @@ export default class ShoppingListsAPI {
         return await RequestUtils.apiPut('/api/shopping-list/' + id, data);
     }
 
+    static async setDefault(id) {
+        return await RequestUtils.apiPut('/api/shopping-list/' + id + '/default');
+    }
+
     static async delete(id) {
         return await RequestUtils.apiDelete('/api/shopping-list/' + id);
     }

--- a/frontend/src/Views/Dashboard/ShoppingListView.jsx
+++ b/frontend/src/Views/Dashboard/ShoppingListView.jsx
@@ -6,7 +6,7 @@ import store from "@/Store/store";
 import {FormControl, Grid, InputLabel, LinearProgress, MenuItem, Select} from "@mui/material";
 
 
-import {Add, Delete, EditNote, Refresh} from "@mui/icons-material";
+import {Add, Delete, EditNote, Refresh, Star, StarBorder} from "@mui/icons-material";
 import FAB from "@/Components/FAB/FAB";
 import ShoppingListCEDialog from "@/Dialogs/ShoppingListCEDialog";
 import ConfirmDialog from "@/Dialogs/ConfirmDialog";
@@ -96,6 +96,19 @@ const ShoppingListView = () => {
     const handleOpenShoppingListEntryCreateDialog = () => {
         setEditMode(false);
         setShoppingListEntryCUDialogOpen(true);
+    }
+
+    const handleSetDefault = async () => {
+        if(!selectedShoppingListID) return;
+        await toast.promise(
+            ShoppingListsAPI.setDefault(selectedShoppingListID),
+            {
+                loading: 'Ustawianie domyślnej listy...',
+                success: 'Lista ustawiona jako domyślna',
+                error: 'Nie udało się ustawić listy jako domyślnej'
+            }
+        );
+        store.dispatch(requestShoppingLists());
     }
 
     const handleOpenShoppingListEntryEditDialog = (entryID) => {
@@ -195,6 +208,12 @@ const ShoppingListView = () => {
                             disabled={shoppingLists.length === 0}
                             onClick={handleShoppingListDeleteButton}
                             icon={<Delete />}
+                        />
+                        <TooltipIconButton
+                            title={'Ustaw jako domyślną'}
+                            disabled={shoppingLists.length === 0}
+                            onClick={handleSetDefault}
+                            icon={selectedShoppingList?.default ? <Star /> : <StarBorder />}
                         />
                        <TooltipIconButton
                            title={'Odśwież'}


### PR DESCRIPTION
## Summary
- support marking a shopping list as default
- add DB migration and model logic to store default flag
- expose API endpoint to set default list
- enable default flag operations in frontend API
- show button with star icon in shopping list view

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a8a331f548323a1bd174450c0bcd7