### PR TITLE
Add sort toggle to shopping lists

### DIFF
--- a/backend/app/Http/Controllers/ShoppingListsController.php
+++ b/backend/app/Http/Controllers/ShoppingListsController.php
@@ -111,6 +111,7 @@ class ShoppingListsController extends Controller {
             'name' => 'required|string',
             'type' => 'string|in:default,grouped',
             'default' => 'boolean',
+            'sort' => 'boolean',
         ]);
 
          $newShoppingList = ShoppingList::create([
@@ -134,6 +135,7 @@ class ShoppingListsController extends Controller {
             'name' => 'string',
             'type' => 'string|in:default,grouped',
             'default' => 'boolean',
+            'sort' => 'boolean',
         ]);
 
         $shoppingList->update($fields);
@@ -151,6 +153,19 @@ class ShoppingListsController extends Controller {
         $this->authorize('update', $shoppingList);
 
         $shoppingList->update(['default' => true]);
+        $shoppingList = $shoppingList->refresh();
+
+        return ResponseUtils::generateSuccessResponse($shoppingList);
+    }
+
+    public function setSort(ShoppingList $shoppingList, Request $request) {
+        $this->authorize('update', $shoppingList);
+
+        $fields = $request->validate([
+            'sort' => 'required|boolean',
+        ]);
+
+        $shoppingList->update(['sort' => $fields['sort']]);
         $shoppingList = $shoppingList->refresh();
 
         return ResponseUtils::generateSuccessResponse($shoppingList);

--- a/backend/app/Models/ShoppingList.php
+++ b/backend/app/Models/ShoppingList.php
@@ -10,10 +10,12 @@ class ShoppingList extends Model {
         'user_id',
         'type',
         'default',
+        'sort',
     ];
 
     protected $casts = [
         'default' => 'boolean',
+        'sort' => 'boolean',
     ];
 
     protected $with = [

--- a/backend/database/migrations/2025_06_25_000000_add_sort_flag_to_shopping_lists_table.php
+++ b/backend/database/migrations/2025_06_25_000000_add_sort_flag_to_shopping_lists_table.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void {
+        Schema::table('shopping_lists', function (Blueprint $table) {
+            $table->boolean('sort')->default(false);
+        });
+    }
+
+    public function down(): void {
+        Schema::table('shopping_lists', function (Blueprint $table) {
+            $table->dropColumn('sort');
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -80,6 +80,7 @@ Route::middleware('auth:sanctum')->group(fn() => [
         Route::get('/{shoppingList}',[ShoppingListsController::class,'show']),
         Route::match(['put','patch'],'/{shoppingList}',[ShoppingListsController::class,'update']),
         Route::match(['put','patch'],'/{shoppingList}/default',[ShoppingListsController::class,'setDefault']),
+        Route::match(['put','patch'],'/{shoppingList}/sort',[ShoppingListsController::class,'setSort']),
         Route::delete('/{shoppingList}',[ShoppingListsController::class,'destroy']),
 
 

--- a/frontend/src/API/ShoppingListsAPI.js
+++ b/frontend/src/API/ShoppingListsAPI.js
@@ -32,6 +32,10 @@ export default class ShoppingListsAPI {
         return await RequestUtils.apiPut('/api/shopping-list/' + id + '/default');
     }
 
+    static async setSort(id, sort) {
+        return await RequestUtils.apiPut('/api/shopping-list/' + id + '/sort', {sort});
+    }
+
     static async delete(id) {
         return await RequestUtils.apiDelete('/api/shopping-list/' + id);
     }

--- a/frontend/src/Utils/ShoppingListUtils.js
+++ b/frontend/src/Utils/ShoppingListUtils.js
@@ -10,22 +10,24 @@ export default class ShoppingListUtils {
 
         if(!shoppingList) return [];
 
-        let {type, entries} = shoppingList;
+        let {type, entries, sort} = shoppingList;
         if(type === 'default'){
             console.log('ENT',entries);
+            let unchecked = entries.filter(entry => !entry.checked).map(entry => ({
+                type: 'entry',
+                ...entry
+            }));
+            let checkedEntries = entries.filter(entry => entry.checked).map(entry => ({
+                type: 'entry',
+                ...entry
+            }));
+            if(sort){
+                unchecked = unchecked.sort((a, b) => a.product_name.localeCompare(b.product_name));
+                checkedEntries = checkedEntries.sort((a, b) => a.product_name.localeCompare(b.product_name));
+            }
             shoppingListToReturn = [
-                ...entries.filter(entry => !entry.checked).map(entry => {
-                    return {
-                        type: 'entry',
-                        ...entry
-                    }
-                }).sort((a, b) => a.product_name.localeCompare(b.product_name)),
-                ...entries.filter(entry => entry.checked).map(entry => {
-                    return {
-                        type: 'entry',
-                        ...entry
-                    }
-                }).sort((a, b) => a.product_name.localeCompare(b.product_name))
+                ...unchecked,
+                ...checkedEntries
             ];
         } else if(type === 'grouped'){
 
@@ -49,17 +51,19 @@ export default class ShoppingListUtils {
                     }
 
 
+                    let items = entries.map(entry => ({
+                        type: 'entry',
+                        ...entry
+                    }));
+                    if(sort)
+                        items = items.sort((a,b) => a.product_name.localeCompare(b.product_name));
+
                     shoppingListToReturn = [...shoppingListToReturn,
                         {
                             type: 'category',
                             category: category
                         },
-                        ...entries.map(entry => {
-                            return {
-                                type: 'entry',
-                                ...entry
-                            }
-                        })
+                        ...items
                     ];
                 });
             if(entries.filter(entry => entry.checked).length > 0){
@@ -68,12 +72,14 @@ export default class ShoppingListUtils {
                         type: 'category',
                         category: 'Zaznaczone'
                     },
-                    ...entries.filter(entry => entry.checked).map(entry => {
-                        return {
-                            type: 'entry',
-                            ...entry
-                        }
-                    })
+                    ...(sort ?
+                        entries.filter(entry => entry.checked)
+                            .map(entry => ({type:'entry',...entry}))
+                            .sort((a,b)=>a.product_name.localeCompare(b.product_name))
+                        :
+                        entries.filter(entry => entry.checked)
+                            .map(entry => ({type:'entry',...entry}))
+                    )
                 ];
             }
         }

--- a/frontend/src/Views/Dashboard/ShoppingListView.jsx
+++ b/frontend/src/Views/Dashboard/ShoppingListView.jsx
@@ -6,7 +6,7 @@ import store from "@/Store/store";
 import {FormControl, Grid, InputLabel, LinearProgress, MenuItem, Select} from "@mui/material";
 
 
-import {Add, Delete, EditNote, Refresh, Star, StarBorder} from "@mui/icons-material";
+import {Add, Delete, EditNote, Refresh, Star, StarBorder, SortByAlpha} from "@mui/icons-material";
 import FAB from "@/Components/FAB/FAB";
 import ShoppingListCEDialog from "@/Dialogs/ShoppingListCEDialog";
 import ConfirmDialog from "@/Dialogs/ConfirmDialog";
@@ -113,6 +113,19 @@ const ShoppingListView = () => {
         store.dispatch(requestShoppingLists());
     }
 
+    const handleToggleSort = async () => {
+        if(!selectedShoppingListID) return;
+        await toast.promise(
+            ShoppingListsAPI.setSort(selectedShoppingListID, !selectedShoppingList.sort),
+            {
+                loading: 'Aktualizowanie sortowania...',
+                success: 'Zmieniono sortowanie',
+                error: 'Nie udało się zmienić sortowania'
+            }
+        );
+        store.dispatch(requestShoppingLists());
+    }
+
     const handleOpenShoppingListEntryEditDialog = (entryID) => {
         setEditEntryID(entryID);
         setEditMode(true);
@@ -214,6 +227,12 @@ const ShoppingListView = () => {
                             disabled={shoppingLists.length === 0}
                             onClick={handleSetDefault}
                             icon={selectedShoppingList?.default ? <Star /> : <StarBorder />}
+                        />
+                        <TooltipIconButton
+                            title={'Sortuj alfabetycznie'}
+                            disabled={shoppingLists.length === 0}
+                            onClick={handleToggleSort}
+                            icon={<SortByAlpha color={selectedShoppingList?.sort ? 'primary' : 'inherit'} />}
                         />
                        <TooltipIconButton
                            title={'Odśwież'}


### PR DESCRIPTION
## Summary
- allow shopping lists to store a `sort` flag
- expose API endpoint to update sort flag
- add migration for `sort` column
- support toggling sort flag from the frontend
- update list rendering logic to respect the sort option

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a97dea19c8323a46919620d73d0d2