### PR TITLE
Add shelf feature

### DIFF
--- a/backend/app/Http/Controllers/ShelfEntriesController.php
+++ b/backend/app/Http/Controllers/ShelfEntriesController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ShelfEntry;
+use App\Models\GlobalUnit;
+use App\Utils\ResponseUtils;
+use Illuminate\Http\Request;
+
+class ShelfEntriesController extends Controller
+{
+    public function __construct()
+    {
+        $this->authorizeResource(ShelfEntry::class, 'shelfEntry');
+    }
+
+    public function index(Request $request)
+    {
+        return ResponseUtils::generateSuccessResponse($request->user()->shelfEntries);
+    }
+
+    public function store(Request $request)
+    {
+        $fields = $request->validate([
+            'product_name' => 'string|required',
+            'amount' => 'numeric',
+            'unit_id' => 'numeric|exists:global_units,id|nullable',
+            'bought_at' => 'date|nullable',
+            'expires_at' => 'date|nullable',
+        ]);
+
+        if(isset($fields['unit_id'])) {
+            $unit = GlobalUnit::find($fields['unit_id']);
+            $fields['unit_name'] = $unit->name;
+        }
+
+        $entry = $request->user()->shelfEntries()->create($fields);
+
+        return ResponseUtils::generateSuccessResponse($entry, 'OK', 201);
+    }
+
+    public function show(Request $request, ShelfEntry $shelfEntry)
+    {
+        return ResponseUtils::generateSuccessResponse($shelfEntry);
+    }
+
+    public function update(Request $request, ShelfEntry $shelfEntry)
+    {
+        $fields = $request->validate([
+            'product_name' => 'string',
+            'amount' => 'numeric',
+            'unit_id' => 'numeric|exists:global_units,id|nullable',
+            'bought_at' => 'date|nullable',
+            'expires_at' => 'date|nullable',
+        ]);
+
+        if(isset($fields['unit_id'])) {
+            $unit = GlobalUnit::find($fields['unit_id']);
+            $fields['unit_name'] = $unit->name;
+        }
+
+        $shelfEntry->update($fields);
+
+        return ResponseUtils::generateSuccessResponse($shelfEntry);
+    }
+
+    public function destroy(ShelfEntry $shelfEntry)
+    {
+        $shelfEntry->delete();
+        return ResponseUtils::generateSuccessResponse();
+    }
+}

--- a/backend/app/Models/ShelfEntry.php
+++ b/backend/app/Models/ShelfEntry.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ShelfEntry extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'product_name',
+        'unit_name',
+        'unit_id',
+        'amount',
+        'bought_at',
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'amount' => 'float',
+        'bought_at' => 'datetime',
+        'expires_at' => 'datetime',
+    ];
+
+    protected $with = [
+        'unit',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function unit()
+    {
+        return $this->belongsTo(GlobalUnit::class, 'unit_id');
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -70,6 +70,10 @@ class User extends Authenticatable
         return $this->hasMany(Training::class);
     }
 
+    public function shelfEntries(): \Illuminate\Database\Eloquent\Relations\HasMany {
+        return $this->hasMany(ShelfEntry::class);
+    }
+
     public function recalculate() {
 
 

--- a/backend/app/Policies/ShelfEntryPolicy.php
+++ b/backend/app/Policies/ShelfEntryPolicy.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\ShelfEntry;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ShelfEntryPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, ShelfEntry $shelfEntry): bool
+    {
+        return $shelfEntry->user_id == $user->id;
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, ShelfEntry $shelfEntry): bool
+    {
+        return $shelfEntry->user_id == $user->id;
+    }
+
+    public function delete(User $user, ShelfEntry $shelfEntry): bool
+    {
+        return $shelfEntry->user_id == $user->id;
+    }
+}

--- a/backend/app/Providers/AuthServiceProvider.php
+++ b/backend/app/Providers/AuthServiceProvider.php
@@ -7,6 +7,7 @@ namespace App\Providers;
 use App\Models\GlobalUnit;
 use App\Models\Product;
 use App\Models\ProductCategory;
+use App\Models\ShelfEntry;
 use App\Models\ProductUnit;
 use App\Models\ShoppingList;
 use App\Models\ShoppingListEntry;
@@ -14,6 +15,7 @@ use App\Policies\GlobalUnitPolicy;
 use App\Policies\ProductCategoryPolicy;
 use App\Policies\ProductPolicy;
 use App\Policies\ProductUnitPolicy;
+use App\Policies\ShelfEntryPolicy;
 use App\Policies\ShoppingListEntryPolicy;
 use App\Policies\ShoppingListPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
@@ -34,6 +36,7 @@ class AuthServiceProvider extends ServiceProvider
         ProductUnit::class => ProductUnitPolicy::class,
         GlobalUnit::class => GlobalUnitPolicy::class,
         ProductCategory::class => ProductCategoryPolicy::class,
+        ShelfEntry::class => ShelfEntryPolicy::class,
     ];
 
     /**

--- a/backend/database/migrations/2025_06_26_000000_create_shelf_entries_table.php
+++ b/backend/database/migrations/2025_06_26_000000_create_shelf_entries_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('shelf_entries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+            $table->string('product_name');
+            $table->decimal('amount',10,2)->default(0);
+            $table->foreignId('unit_id')->nullable()->constrained('global_units');
+            $table->string('unit_name')->default('');
+            $table->date('bought_at')->nullable();
+            $table->date('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('shelf_entries');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -23,6 +23,7 @@ use App\Http\Controllers\ShoppingListEntriesController;
 use App\Http\Controllers\ShoppingListsController;
 use App\Http\Controllers\TrainingsController;
 use App\Http\Controllers\UserController;
+use App\Http\Controllers\ShelfEntriesController;
 use App\Models\Product;
     use App\Models\ProductUnit;
     use App\Models\ShoppingList;
@@ -268,6 +269,17 @@ Route::middleware('auth:sanctum')->group(fn() => [
 
             ]),
 
+    ]),
+
+    //-----------------------------
+    //Shelf routes
+    //-----------------------------
+    Route::prefix('/shelf')->group(fn() => [
+        Route::get('/',[ShelfEntriesController::class,'index']),
+        Route::post('/',[ShelfEntriesController::class,'store']),
+        Route::get('/{shelfEntry}',[ShelfEntriesController::class,'show']),
+        Route::match(['put','patch'],'/{shelfEntry}',[ShelfEntriesController::class,'update']),
+        Route::delete('/{shelfEntry}',[ShelfEntriesController::class,'destroy']),
     ]),
 
     //-----------------------------

--- a/backend/tests/Feature/RESTAPI/ShelfEntriesAPITest.php
+++ b/backend/tests/Feature/RESTAPI/ShelfEntriesAPITest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\RESTAPI;
+
+use App\Models\GlobalUnit;
+use App\Models\ShelfEntry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\Helpers\ShelfEntriesTestHelper;
+use Tests\TestCase;
+
+class ShelfEntriesAPITest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    const ENDPOINT = '/api/shelf';
+
+    protected User $user1;
+    protected User $user2;
+    protected $unitId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user1 = User::factory()->create();
+        $this->user2 = User::factory()->create();
+        $this->unitId = GlobalUnit::first()->id;
+    }
+
+    protected function createEntry(User $user, $data = [])
+    {
+        if($data === [])
+            $data = ShelfEntriesTestHelper::generateShelfEntryData($this->faker, $this->unitId);
+        return $this->actingAs($user)->postJson(self::ENDPOINT, $data);
+    }
+
+    public function test_user_can_create_shelf_entry()
+    {
+        $data = ShelfEntriesTestHelper::generateShelfEntryData($this->faker, $this->unitId);
+        $response = $this->createEntry($this->user1, $data);
+        $response->assertStatus(201);
+        $this->assertDatabaseCount('shelf_entries', 1);
+    }
+
+    public function test_user_can_list_own_entries()
+    {
+        $this->createEntry($this->user1);
+        $response = $this->actingAs($this->user1)->getJson(self::ENDPOINT);
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'data');
+    }
+
+    public function test_user_can_update_entry()
+    {
+        $entry = $this->createEntry($this->user1)->json('data');
+        $newData = ShelfEntriesTestHelper::generateShelfEntryData($this->faker, $this->unitId);
+        $response = $this->actingAs($this->user1)->putJson(self::ENDPOINT.'/'.$entry['id'], $newData);
+        $response->assertStatus(200);
+    }
+
+    public function test_user_can_delete_entry()
+    {
+        $entry = $this->createEntry($this->user1)->json('data');
+        $response = $this->actingAs($this->user1)->deleteJson(self::ENDPOINT.'/'.$entry['id']);
+        $response->assertStatus(200);
+        $this->assertDatabaseCount('shelf_entries', 0);
+    }
+
+    public function test_user_cannot_access_other_users_entry()
+    {
+        $entry = $this->createEntry($this->user1)->json('data');
+        $response = $this->actingAs($this->user2)->getJson(self::ENDPOINT.'/'.$entry['id']);
+        $response->assertStatus(403);
+    }
+}

--- a/backend/tests/Helpers/ShelfEntriesTestHelper.php
+++ b/backend/tests/Helpers/ShelfEntriesTestHelper.php
@@ -1,0 +1,16 @@
+<?php
+namespace Tests\Helpers;
+
+use Faker\Generator;
+
+class ShelfEntriesTestHelper {
+    public static function generateShelfEntryData(Generator $faker, $unitId = 1): array {
+        return [
+            'product_name' => $faker->name,
+            'amount' => (float)$faker->randomDigit(),
+            'unit_id' => $unitId,
+            'bought_at' => $faker->date(),
+            'expires_at' => $faker->date(),
+        ];
+    }
+}

--- a/frontend/src/API/ShelfEntriesAPI.js
+++ b/frontend/src/API/ShelfEntriesAPI.js
@@ -1,0 +1,27 @@
+import RequestUtils from "@/Utils/RequestUtils";
+
+export default class ShelfEntriesAPI {
+    static async getAll() {
+        return await RequestUtils.apiGet('/api/shelf');
+    }
+
+    static async get(id) {
+        return await RequestUtils.apiGet('/api/shelf/' + id);
+    }
+
+    static async create(data) {
+        const result = await RequestUtils.apiPost('/api/shelf', data);
+        if(result.status >= 300) {
+            throw new Error('ShelfEntriesAPI.create() failed, status: ' + result.status);
+        }
+        return result;
+    }
+
+    static async update(id, data) {
+        return await RequestUtils.apiPut('/api/shelf/' + id, data);
+    }
+
+    static async delete(id) {
+        return await RequestUtils.apiDelete('/api/shelf/' + id);
+    }
+}

--- a/frontend/src/Components/Navigation/Navigation.jsx
+++ b/frontend/src/Components/Navigation/Navigation.jsx
@@ -13,6 +13,7 @@ import chevronLeft from '@iconify/icons-mdi/chevron-left';
 import burgerIcon from '@iconify/icons-mdi/burger';
 import calendarIcon from '@iconify/icons-mdi/calendar';
 import gearIcon from '@iconify/icons-mdi/gear';
+import fridgeIcon from '@iconify/icons-mdi/fridge-outline';
 import AuthAPI from "@/API/AuthAPI";
 import store from "@/Store/store";
 import {logout} from "@/Store/Reducers/AuthReducer";
@@ -120,6 +121,7 @@ const Navigation = ({
                 <NavItem name={'Przepisy'} icon={receiptText} url={'/przepisy'} />
                 <NavItem name={'Fast Food'} icon={burgerIcon} url={'/fast-food'} />
                 <NavItem name={'Produkty'} icon={fruitWatermelon} url={'/produkty'} />
+                <NavItem name={'Szafka'} icon={fridgeIcon} url={'/szafka'} />
                 <NavItem name={'Ustawienia aplikacji'} icon={gearIcon} url={'/admin/ustawienia'} />
 
             </nav>

--- a/frontend/src/Dialogs/ShelfEntryCEDialog.jsx
+++ b/frontend/src/Dialogs/ShelfEntryCEDialog.jsx
@@ -1,0 +1,163 @@
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    FormControl,
+    Grid,
+    InputLabel,
+    MenuItem,
+    Select,
+    TextField,
+    Grow
+} from "@mui/material";
+import {forwardRef, useEffect, useRef} from "react";
+import {useFormik} from "formik";
+import {useSelector} from "react-redux";
+import ShelfEntrySchema from "@/Schemas/ShelfEntrySchema";
+import ShelfEntriesAPI from "@/API/ShelfEntriesAPI";
+import {requestGlobalUnits} from "@/Store/Reducers/GlobalUnitReducer";
+import store from "@/Store/store";
+import toast from "react-hot-toast";
+
+const Transition = forwardRef(function Transition(props, ref) {
+    return <Grow ref={ref} {...props} />;
+});
+
+const ShelfEntryCEDialog = ({
+    open = false,
+    onClose = () => {},
+    editMode = false,
+    editEntry = null,
+}) => {
+
+    const {globalUnits} = useSelector(state => state.globalUnitReducer);
+    const mainInput = useRef(null);
+
+    const formik = useFormik({
+        initialValues: {
+            product_name: '',
+            amount: 0,
+            unit_id: '',
+            bought_at: '',
+            expires_at: '',
+        },
+        validationSchema: ShelfEntrySchema,
+        onSubmit: async (values) => {
+            try {
+                if(editMode) {
+                    await ShelfEntriesAPI.update(editEntry.id, values);
+                } else {
+                    await ShelfEntriesAPI.create(values);
+                }
+                onClose(true);
+            } catch (e) {
+                toast.error('Nie udało się zapisać danych');
+            }
+        }
+    });
+
+    useEffect(() => {
+        if(open){
+            store.dispatch(requestGlobalUnits());
+            formik.resetForm();
+            if(editMode && editEntry){
+                formik.setValues({
+                    product_name: editEntry.product_name,
+                    amount: editEntry.amount,
+                    unit_id: editEntry.unit_id || '',
+                    bought_at: editEntry.bought_at ? editEntry.bought_at.substring(0,10) : '',
+                    expires_at: editEntry.expires_at ? editEntry.expires_at.substring(0,10) : '',
+                });
+            } else {
+                formik.setFieldValue('unit_id', globalUnits?.[0]?.id || '');
+            }
+            mainInput.current?.focus();
+        }
+    }, [open, editMode]);
+
+    const handleClose = () => onClose(false);
+
+    return (
+        <Dialog open={open} TransitionComponent={Transition} fullWidth maxWidth={'sm'} onClose={handleClose}>
+            <DialogTitle>{editMode ? 'Edytuj wpis' : 'Dodaj wpis'}</DialogTitle>
+            <form onSubmit={formik.handleSubmit}>
+                <DialogContent>
+                    <Grid container spacing={2}>
+                        <Grid item xs={12}>
+                            <TextField
+                                inputRef={mainInput}
+                                variant={'standard'}
+                                name={'product_name'}
+                                label={'Nazwa'}
+                                value={formik.values.product_name}
+                                onChange={formik.handleChange}
+                                fullWidth
+                                error={formik.touched.product_name && Boolean(formik.errors.product_name)}
+                                helperText={formik.touched.product_name && formik.errors.product_name}
+                            />
+                        </Grid>
+                        <Grid item xs={12} md={6}>
+                            <TextField
+                                variant={'standard'}
+                                name={'amount'}
+                                type={'number'}
+                                label={'Ilość'}
+                                value={formik.values.amount}
+                                onChange={formik.handleChange}
+                                fullWidth
+                                error={formik.touched.amount && Boolean(formik.errors.amount)}
+                                helperText={formik.touched.amount && formik.errors.amount}
+                            />
+                        </Grid>
+                        <Grid item xs={12} md={6}>
+                            <FormControl fullWidth variant={'standard'}>
+                                <InputLabel>Jednostka</InputLabel>
+                                <Select
+                                    value={formik.values.unit_id}
+                                    name={'unit_id'}
+                                    label={'Jednostka'}
+                                    onChange={formik.handleChange}
+                                >
+                                    <MenuItem value=''><em>Brak</em></MenuItem>
+                                    {globalUnits.map(unit => <MenuItem key={unit.id} value={unit.id}>{unit.name}</MenuItem>)}
+                                </Select>
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={12} md={6}>
+                            <TextField
+                                variant={'standard'}
+                                name={'bought_at'}
+                                type={'date'}
+                                label={'Data zakupu'}
+                                InputLabelProps={{shrink:true}}
+                                value={formik.values.bought_at}
+                                onChange={formik.handleChange}
+                                fullWidth
+                            />
+                        </Grid>
+                        <Grid item xs={12} md={6}>
+                            <TextField
+                                variant={'standard'}
+                                name={'expires_at'}
+                                type={'date'}
+                                label={'Data ważności'}
+                                InputLabelProps={{shrink:true}}
+                                value={formik.values.expires_at}
+                                onChange={formik.handleChange}
+                                fullWidth
+                            />
+                        </Grid>
+                    </Grid>
+                </DialogContent>
+                <DialogActions>
+                    <Button color={'warning'} onClick={handleClose}>Anuluj</Button>
+                    <Button type={'submit'}>{editMode ? 'Zapisz' : 'Dodaj'}</Button>
+                </DialogActions>
+            </form>
+        </Dialog>
+    );
+};
+
+export default ShelfEntryCEDialog;

--- a/frontend/src/Routes/Router.jsx
+++ b/frontend/src/Routes/Router.jsx
@@ -23,6 +23,7 @@ import BarcodeResultsView from "@/Views/Dashboard/BarcodeResultsView";
 import FastFoodsView from "@/Views/Dashboard/FastFoodsView";
 import FastFoodEditView from "@/Views/Dashboard/FastFoodEditView";
 import FastFoodView from "@/Views/Dashboard/FastFoodView";
+import ShelfView from "@/Views/Dashboard/ShelfView";
 
 const Router = () => {
 
@@ -58,6 +59,7 @@ const Router = () => {
                                 <Route path="/przepisy/:id/edycja" element={<RecipeEditView />} />
                                 <Route path="/produkty" element={<ProductsView />} />
                                 <Route path="/produkty/:id" element={<ProductView />} />
+                                <Route path="/szafka" element={<ShelfView />} />
                                 <Route path="/kategorie" element={<CategoriesView />} />
                                 <Route path="/profil" element={<ProfileView />} />
                                 <Route path="/ustawienia" element={<UserSettingsView />} />

--- a/frontend/src/Schemas/ShelfEntrySchema.js
+++ b/frontend/src/Schemas/ShelfEntrySchema.js
@@ -1,0 +1,11 @@
+import * as Yup from 'yup';
+
+const ShelfEntrySchema = Yup.object().shape({
+    product_name: Yup.string().required('Pole wymagane'),
+    amount: Yup.number().min(0, 'Nieprawidłowa wartość'),
+    unit_id: Yup.number().nullable(),
+    bought_at: Yup.date().nullable(),
+    expires_at: Yup.date().nullable(),
+});
+
+export default ShelfEntrySchema;

--- a/frontend/src/Views/Dashboard/ShelfView.jsx
+++ b/frontend/src/Views/Dashboard/ShelfView.jsx
@@ -1,0 +1,81 @@
+import styled from "styled-components";
+import {useEffect, useState} from "react";
+import ShelfEntriesAPI from "@/API/ShelfEntriesAPI";
+import DataTable from "@/Components/DataTable/DataTable";
+import {Add, Delete, Edit} from "@mui/icons-material";
+import toast from "react-hot-toast";
+import ShelfEntryCEDialog from "@/Dialogs/ShelfEntryCEDialog";
+
+const Container = styled.div`
+  min-height: calc(100% - 100px);
+  margin: 20px auto;
+  padding: 30px;
+  border-radius: 10px;
+  width: calc(100% - 100px);
+`;
+
+const columns = [
+    {name:'id', label:'ID'},
+    {name:'product_name', label:'Nazwa'},
+    {name:'amount', label:'Ilość'},
+    {name:'unit_name', label:'Jednostka'},
+    {name:'bought_at', label:'Data zakupu'},
+    {name:'expires_at', label:'Data ważności'},
+];
+
+const ShelfView = () => {
+    const [entries,setEntries] = useState([]);
+    const [isLoading,setIsLoading] = useState(false);
+    const [selectedIds,setSelectedIds] = useState([]);
+    const [dialogOpen,setDialogOpen] = useState(false);
+    const [editMode,setEditMode] = useState(false);
+    const [editEntry,setEditEntry] = useState(null);
+
+    const load = async () => {
+        setIsLoading(true);
+        const res = await ShelfEntriesAPI.getAll();
+        if(res.status === 200) setEntries(res.data.data);
+        setIsLoading(false);
+    };
+
+    useEffect(() => { load(); }, []);
+
+    const handleDialogClose = (success) => {
+        setDialogOpen(false);
+        setEditMode(false);
+        setEditEntry(null);
+        if(success) load();
+    };
+
+    const deleteSelected = async () => {
+        for(const id of selectedIds){
+            await ShelfEntriesAPI.delete(id);
+        }
+        load();
+    };
+
+    const tools = [
+        {name:'add', label:'Dodaj', icon:<Add />, onClick:() => {setEditMode(false); setDialogOpen(true);}},
+        {name:'delete', label:'Usuń', icon:<Delete />, forSelect:true, onClick:() => toast.promise(deleteSelected(),{loading:'Usuwanie...',success:'Usunięto',error:'Błąd'})}
+    ];
+
+    const inlineTools = [
+        {name:'edit', label:'Edytuj', icon:<Edit />, onClick:(row) => {setEditEntry(row); setEditMode(true); setDialogOpen(true);}}
+    ];
+
+    return <Container>
+        <ShelfEntryCEDialog open={dialogOpen} onClose={handleDialogClose} editMode={editMode} editEntry={editEntry} />
+        <DataTable
+            title={'Szafka'}
+            isLoading={isLoading}
+            searchBar={true}
+            data={entries}
+            columns={columns}
+            tools={tools}
+            inlineTools={inlineTools}
+            onSelect={setSelectedIds}
+        />
+    </Container>;
+};
+
+export default ShelfView;


### PR DESCRIPTION
## Summary
- add ShelfEntry model and controller
- migrate shelf_entries table
- register ShelfEntry policy and routes
- implement ShelfEntry CRUD API and tests
- add Shelf view, dialog, schema and API on frontend
- hook Shelf into router and navigation

## Testing
- `composer install` *(fails: command not found)*
- `./vendor/bin/phpunit --stop-on-failure` *(fails: command not found)*
- `npm test --silent` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b0ccd6e6483239d54a83cc49f21e9