### PR TITLE
Add recipe variant support for meal planning

### DIFF
--- a/backend/app/Http/Controllers/CalendarEntriesController.php
+++ b/backend/app/Http/Controllers/CalendarEntriesController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\CalendarEntry;
 use App\Models\FastFoodStore;
 use App\Models\Recipe;
+use App\Models\RecipeVariant;
 use App\Utils\ResponseUtils;
 use Illuminate\Http\Request;
 
@@ -160,17 +161,30 @@ class CalendarEntriesController extends Controller
     public function storeFromRecipe(Request $request) {
         $fields = $request->validate([
             'recipe_id' => 'required|integer',
+            'recipe_variant_id' => 'integer|exists:recipe_variants,id|nullable',
             'date' => 'required|date',
             'meal_order' => 'integer|required',
         ]);
 
         $user = $request->user();
         $recipe = Recipe::findOrFail($fields['recipe_id']);
+        $variant = isset($fields['recipe_variant_id'])
+            ? RecipeVariant::findOrFail($fields['recipe_variant_id'])
+            : $recipe->variants()->where('is_default', true)->first();
+
+        if($variant && $variant->recipe_id !== $recipe->id) {
+            return ResponseUtils::generateErrorResponse('Invalid variant for recipe', 422);
+        }
+
+        if(!$variant) {
+            $variant = $recipe->variants()->first();
+        }
 
         $entry = $user->calendarEntries()->create([
             'recipe_id' => $recipe->id,
+            'recipe_variant_id' => $variant?->id,
             'entry_type' => 'from_recipe',
-            'calories' => $recipe->calories_per_serving,
+            'calories' => $variant?->calories_per_serving ?? $recipe->calories_per_serving,
             'date' => $fields['date'],
             'meal_order' => $fields['meal_order'],
         ]);
@@ -179,21 +193,32 @@ class CalendarEntriesController extends Controller
     }
 
     public function updateFromRecipe(Request $request, CalendarEntry $calendarEntry) {
-        $request = $request->validate([
+        $fields = $request->validate([
             'recipe_id' => 'integer',
+            'recipe_variant_id' => 'integer|exists:recipe_variants,id|nullable',
             'date' => 'date',
             'meal_order' => 'integer',
         ]);
 
-        $user = $request->user();
+        $recipe = Recipe::findOrFail($fields['recipe_id']);
+        $variant = isset($fields['recipe_variant_id'])
+            ? RecipeVariant::findOrFail($fields['recipe_variant_id'])
+            : $recipe->variants()->where('is_default', true)->first();
 
-        $recipe = Recipe::findOrFail($request['recipe_id']);
+        if($variant && $variant->recipe_id !== $recipe->id) {
+            return ResponseUtils::generateErrorResponse('Invalid variant for recipe', 422);
+        }
+
+        if(!$variant) {
+            $variant = $recipe->variants()->first();
+        }
 
         $calendarEntry->update([
             'recipe_id' => $recipe->id,
-            'calories' => $recipe->calories_per_serving,
-            'date' => $request['date'],
-            'meal_order' => $request['meal_order'],
+            'recipe_variant_id' => $variant?->id,
+            'calories' => $variant?->calories_per_serving ?? $recipe->calories_per_serving,
+            'date' => $fields['date'],
+            'meal_order' => $fields['meal_order'],
         ]);
 
         return ResponseUtils::generateSuccessResponse($calendarEntry);

--- a/backend/app/Http/Controllers/RecipeIngredientsController.php
+++ b/backend/app/Http/Controllers/RecipeIngredientsController.php
@@ -4,39 +4,51 @@ namespace App\Http\Controllers;
 
 use App\Models\Ingredient;
 use App\Models\Recipe;
+use App\Models\RecipeVariant;
 use App\Utils\ResponseUtils;
 use Illuminate\Http\Request;
 
 class RecipeIngredientsController extends Controller {
 
-    public function index(Recipe $recipe) {
+    public function index(Recipe $recipe, RecipeVariant $recipeVariant) {
+        if($recipeVariant->recipe_id !== $recipe->id) {
+            return ResponseUtils::generateErrorResponse('Not found',404);
+        }
 
-        return ResponseUtils::generateSuccessResponse($recipe->ingredients()->get());
+        return ResponseUtils::generateSuccessResponse($recipeVariant->ingredients()->get());
     }
 
-    public function store(Recipe $recipe,Request $request) {
+    public function store(Recipe $recipe, RecipeVariant $recipeVariant, Request $request) {
         $fields = $request->validate([
             'product_id' => 'required|numeric|exists:products,id',
             'product_unit_id' => 'required|numeric|exists:product_units,id',
             'amount_in_unit' => 'required|numeric',
         ]);
 
-        $newObj = $recipe->ingredients()->create($fields);
+        if($recipeVariant->recipe_id !== $recipe->id) {
+            return ResponseUtils::generateErrorResponse('Not found',404);
+        }
+
+        $newObj = $recipeVariant->ingredients()->create([
+            ...$fields,
+            'recipe_id' => $recipe->id,
+            'recipe_variant_id' => $recipeVariant->id,
+        ]);
 
         return ResponseUtils::generateSuccessResponse(
             $newObj->where('id',$newObj['id'])->first()
             ,'OK',201);
     }
 
-    public function show(Recipe $recipe, Ingredient $ingredient) {
-        if ($ingredient->recipe_id != $recipe->id) {
+    public function show(Recipe $recipe, RecipeVariant $recipeVariant, Ingredient $ingredient) {
+        if ($ingredient->recipe_id != $recipe->id || $ingredient->recipe_variant_id != $recipeVariant->id) {
             return ResponseUtils::generateErrorResponse('Not found',404);
         }
         return ResponseUtils::generateSuccessResponse($ingredient);
     }
 
-    public function update(Request $request, Recipe $recipe, Ingredient $ingredient) {
-        if ($ingredient->recipe_id != $recipe->id) {
+    public function update(Request $request, Recipe $recipe, RecipeVariant $recipeVariant, Ingredient $ingredient) {
+        if ($ingredient->recipe_id != $recipe->id || $ingredient->recipe_variant_id != $recipeVariant->id) {
             return ResponseUtils::generateErrorResponse('Not found',404);
         }
         $fields = $request->validate([
@@ -48,7 +60,7 @@ class RecipeIngredientsController extends Controller {
         $ingredient->update($fields);
     }
 
-    public function destroy(Recipe $recipe, Ingredient $ingredient) {
+    public function destroy(Recipe $recipe, RecipeVariant $recipeVariant, Ingredient $ingredient) {
         $ingredient->delete();
     }
 

--- a/backend/app/Http/Controllers/RecipeVariantsController.php
+++ b/backend/app/Http/Controllers/RecipeVariantsController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Recipe;
+use App\Models\RecipeVariant;
+use App\Utils\ResponseUtils;
+use Illuminate\Http\Request;
+
+class RecipeVariantsController extends Controller
+{
+    public function index(Recipe $recipe)
+    {
+        return ResponseUtils::generateSuccessResponse($recipe->variants()->get());
+    }
+
+    public function store(Request $request, Recipe $recipe)
+    {
+        $fields = $request->validate([
+            'name' => 'required|string',
+            'is_default' => 'boolean',
+        ]);
+
+        $variant = $recipe->variants()->create([
+            'name' => $fields['name'],
+            'is_default' => $fields['is_default'] ?? false,
+            'calories_per_serving' => $recipe->calories_per_serving,
+        ]);
+
+        if ($variant->is_default) {
+            $recipe->variants()->where('id', '!=', $variant->id)->update(['is_default' => false]);
+            $recipe->calories_per_serving = $variant->calories_per_serving;
+            $recipe->saveQuietly();
+        }
+
+        return ResponseUtils::generateSuccessResponse($variant, 'OK', 201);
+    }
+
+    public function show(Recipe $recipe, RecipeVariant $recipeVariant)
+    {
+        if ($recipeVariant->recipe_id !== $recipe->id) {
+            return ResponseUtils::generateErrorResponse('Not found', 404);
+        }
+
+        return ResponseUtils::generateSuccessResponse($recipeVariant);
+    }
+
+    public function update(Request $request, Recipe $recipe, RecipeVariant $recipeVariant)
+    {
+        if ($recipeVariant->recipe_id !== $recipe->id) {
+            return ResponseUtils::generateErrorResponse('Not found', 404);
+        }
+
+        $fields = $request->validate([
+            'name' => 'string',
+            'is_default' => 'boolean',
+        ]);
+
+        $recipeVariant->update($fields);
+
+        if (isset($fields['is_default']) && $fields['is_default']) {
+            $recipe->variants()->where('id', '!=', $recipeVariant->id)->update(['is_default' => false]);
+            $recipe->calories_per_serving = $recipeVariant->calories_per_serving;
+            $recipe->saveQuietly();
+        }
+
+        return ResponseUtils::generateSuccessResponse($recipeVariant);
+    }
+
+    public function destroy(Recipe $recipe, RecipeVariant $recipeVariant)
+    {
+        if ($recipeVariant->recipe_id !== $recipe->id) {
+            return ResponseUtils::generateErrorResponse('Not found', 404);
+        }
+
+        if ($recipe->variants()->count() <= 1) {
+            return ResponseUtils::generateErrorResponse('Cannot remove last variant', 400);
+        }
+
+        $wasDefault = $recipeVariant->is_default;
+        $recipeVariant->delete();
+
+        if ($wasDefault) {
+            $newDefault = $recipe->variants()->first();
+            if ($newDefault) {
+                $newDefault->is_default = true;
+                $newDefault->saveQuietly();
+                $recipe->calories_per_serving = $newDefault->calories_per_serving;
+                $recipe->saveQuietly();
+            }
+        }
+
+        return ResponseUtils::generateSuccessResponse('OK');
+    }
+}

--- a/backend/app/Http/Controllers/RecipesController.php
+++ b/backend/app/Http/Controllers/RecipesController.php
@@ -81,6 +81,12 @@ class RecipesController extends Controller {
 
         $newObj = Recipe::create($fields);
 
+        $newObj->variants()->create([
+            'name' => 'Domyślny',
+            'is_default' => true,
+            'calories_per_serving' => $newObj->calories_per_serving,
+        ]);
+
 
         return ResponseUtils::generateSuccessResponse(
             $newObj->where('id',$newObj['id'])->first()

--- a/backend/app/Models/CalendarEntry.php
+++ b/backend/app/Models/CalendarEntry.php
@@ -8,6 +8,7 @@ class CalendarEntry extends Model
 {
     protected $fillable = [
         'recipe_id',
+        'recipe_variant_id',
         'entry_type',
         'calories',
         'date',
@@ -16,10 +17,14 @@ class CalendarEntry extends Model
         'fast_food_store_id'
     ];
 
-    protected $with = ["recipe", "fastFoodStore", "calendarEntryFastFoodMeals", "calendarEntryIngredients", "calendarEntryQuickEntries"];
+    protected $with = ["recipe", "recipeVariant", "fastFoodStore", "calendarEntryFastFoodMeals", "calendarEntryIngredients", "calendarEntryQuickEntries"];
 
     public function recipe() {
         return $this->belongsTo(Recipe::class);
+    }
+
+    public function recipeVariant() {
+        return $this->belongsTo(RecipeVariant::class);
     }
 
     public function fastFoodStore(): \Illuminate\Database\Eloquent\Relations\BelongsTo
@@ -42,7 +47,7 @@ class CalendarEntry extends Model
     public function recalculate() {
         $calories = 0;
         if ($this->entry_type === 'from_recipe') {
-            $calories = $this->recipe->calories_per_serving;
+            $calories = $this->recipeVariant?->calories_per_serving ?? $this->recipe->calories_per_serving;
         } elseif ($this->entry_type === 'from_fast_food_store') {
             foreach ($this->calendarEntryFastFoodMeals as $meal) {
                 $calories += $meal->calories_per_ration * $meal->quantity;

--- a/backend/app/Models/Ingredient.php
+++ b/backend/app/Models/Ingredient.php
@@ -9,6 +9,7 @@ class   Ingredient extends Model {
 
     protected $fillable = [
         'recipe_id',
+        'recipe_variant_id',
         'product_id',
         'product_unit_id',
         'amount_in_unit',
@@ -20,6 +21,10 @@ class   Ingredient extends Model {
     protected $with = ['product', 'unit'];
     public function recipe() {
         return $this->belongsTo(Recipe::class);
+    }
+
+    public function variant() {
+        return $this->belongsTo(RecipeVariant::class, 'recipe_variant_id');
     }
 
     public function product() {
@@ -36,16 +41,22 @@ class   Ingredient extends Model {
             $model->amount_in_grams = $model->amount_in_unit * $model->unit()->first()->grams_per_unit;
             $model->calories = $model->amount_in_grams * ($model->product->nutrition_energy_kcal/100);
             $model->saveQuietly();
-            $model->recipe->recalculate();
+            if($model->variant) {
+                $model->variant->recalculate();
+            }
         });
         self::updated(function($model) {
             $model->amount_in_grams = $model->amount_in_unit * $model->unit()->first()->grams_per_unit;
             $model->calories = $model->amount_in_grams * ($model->product->nutrition_energy_kcal/100);
             $model->saveQuietly();
-            $model->recipe->recalculate();
+            if($model->variant) {
+                $model->variant->recalculate();
+            }
         });
         self::deleted(function($model) {
-            $model->recipe->recalculate();
+            if($model->variant) {
+                $model->variant->recalculate();
+            }
         });
     }
 

--- a/backend/app/Models/Recipe.php
+++ b/backend/app/Models/Recipe.php
@@ -23,7 +23,7 @@ class Recipe extends Model {
         'created_by',
     ];
 
-    protected $with = ['ingredients'];
+    protected $with = ['variants'];
 
     public function toSearchableArray(): array {
         return [
@@ -33,26 +33,22 @@ class Recipe extends Model {
 
 
     public function ingredients() {
-        return $this->hasMany(Ingredient::class);
+        return $this->hasManyThrough(Ingredient::class, RecipeVariant::class);
+    }
+
+    public function variants() {
+        return $this->hasMany(RecipeVariant::class);
     }
 
     public function recalculate() {
-        $ingredients = $this->ingredients()->get();
-        $calories = 0;
-        foreach ($ingredients as $ingredient) {
-            $ingredient->amount_in_grams = $ingredient->amount_in_unit * $ingredient->unit()->first()->grams_per_unit;
-            $ingredient->calories = $ingredient->amount_in_grams * ($ingredient->product->nutrition_energy_kcal/100);
-            $ingredient->saveQuietly();
-            $calories += $ingredient->calories;
-        }
+        foreach ($this->variants as $variant) {
+            foreach ($variant->ingredients as $ingredient) {
+                $ingredient->amount_in_grams = $ingredient->amount_in_unit * $ingredient->unit()->first()->grams_per_unit;
+                $ingredient->calories = $ingredient->amount_in_grams * ($ingredient->product->nutrition_energy_kcal/100);
+                $ingredient->saveQuietly();
+            }
 
-        $this->calories_per_serving = $calories / $this->serving_amount;
-        $this->saveQuietly();
-
-        $entries = $this->calendarEntries()->get();
-        foreach ($entries as $entry) {
-            $entry->calories = $this->calories_per_serving;
-            $entry->saveQuietly();
+            $variant->recalculate();
         }
 
     }

--- a/backend/app/Models/RecipeVariant.php
+++ b/backend/app/Models/RecipeVariant.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RecipeVariant extends Model
+{
+    protected $fillable = [
+        'recipe_id',
+        'name',
+        'calories_per_serving',
+        'is_default',
+    ];
+
+    protected $with = ['ingredients'];
+
+    protected $casts = [
+        'is_default' => 'boolean',
+    ];
+
+    public function recipe()
+    {
+        return $this->belongsTo(Recipe::class);
+    }
+
+    public function ingredients()
+    {
+        return $this->hasMany(Ingredient::class);
+    }
+
+    public function calendarEntries(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
+        return $this->hasMany(CalendarEntry::class, 'recipe_variant_id');
+    }
+
+    public function recalculate(): void
+    {
+        $calories = 0;
+        foreach ($this->ingredients as $ingredient) {
+            $calories += $ingredient->calories;
+        }
+
+        $servings = max(1, $this->recipe->serving_amount);
+        $this->calories_per_serving = $calories / $servings;
+        $this->saveQuietly();
+
+        if ($this->is_default) {
+            $this->recipe->calories_per_serving = $this->calories_per_serving;
+            $this->recipe->saveQuietly();
+        }
+
+        foreach ($this->calendarEntries as $entry) {
+            $entry->calories = $this->calories_per_serving;
+            $entry->saveQuietly();
+        }
+    }
+
+    public static function boot()
+    {
+        parent::boot();
+
+        self::deleted(function ($model) {
+            $model->ingredients()->delete();
+        });
+    }
+}

--- a/backend/database/migrations/2025_07_01_000000_create_recipe_variants_table.php
+++ b/backend/database/migrations/2025_07_01_000000_create_recipe_variants_table.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('recipe_variants', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('recipe_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->decimal('calories_per_serving')->default(0);
+            $table->boolean('is_default')->default(false);
+            $table->timestamps();
+        });
+
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->foreignId('recipe_variant_id')->nullable()->after('recipe_id')->constrained('recipe_variants');
+        });
+
+        Schema::table('calendar_entries', function (Blueprint $table) {
+            $table->foreignId('recipe_variant_id')->nullable()->after('recipe_id')->constrained('recipe_variants');
+        });
+
+        $recipes = DB::table('recipes')->get();
+        foreach ($recipes as $recipe) {
+            $variantId = DB::table('recipe_variants')->insertGetId([
+                'recipe_id' => $recipe->id,
+                'name' => 'Domyślny',
+                'calories_per_serving' => $recipe->calories_per_serving,
+                'is_default' => true,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            DB::table('ingredients')
+                ->where('recipe_id', $recipe->id)
+                ->update(['recipe_variant_id' => $variantId]);
+
+            $ingredientsCalories = DB::table('ingredients')
+                ->where('recipe_id', $recipe->id)
+                ->sum('calories');
+
+            $servings = max(1, (int)$recipe->serving_amount);
+            $caloriesPerServing = $servings > 0 ? $ingredientsCalories / $servings : 0;
+
+            DB::table('recipe_variants')
+                ->where('id', $variantId)
+                ->update(['calories_per_serving' => $caloriesPerServing]);
+
+            DB::table('calendar_entries')
+                ->where('recipe_id', $recipe->id)
+                ->update(['recipe_variant_id' => $variantId]);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('calendar_entries', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('recipe_variant_id');
+        });
+
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('recipe_variant_id');
+        });
+
+        Schema::dropIfExists('recipe_variants');
+    }
+};

--- a/backend/database/migrations/2025_07_01_010000_update_recipe_variant_foreign_keys.php
+++ b/backend/database/migrations/2025_07_01_010000_update_recipe_variant_foreign_keys.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->dropForeign(['recipe_variant_id']);
+        });
+
+        Schema::table('calendar_entries', function (Blueprint $table) {
+            $table->dropForeign(['recipe_variant_id']);
+        });
+
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->foreign('recipe_variant_id')
+                ->references('id')
+                ->on('recipe_variants')
+                ->cascadeOnDelete();
+        });
+
+        Schema::table('calendar_entries', function (Blueprint $table) {
+            $table->foreign('recipe_variant_id')
+                ->references('id')
+                ->on('recipe_variants')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->dropForeign(['recipe_variant_id']);
+        });
+
+        Schema::table('calendar_entries', function (Blueprint $table) {
+            $table->dropForeign(['recipe_variant_id']);
+        });
+
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->foreign('recipe_variant_id')
+                ->references('id')
+                ->on('recipe_variants');
+        });
+
+        Schema::table('calendar_entries', function (Blueprint $table) {
+            $table->foreign('recipe_variant_id')
+                ->references('id')
+                ->on('recipe_variants');
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\ProductsController;
     use App\Http\Controllers\ProductUnitController;
 use App\Http\Controllers\RecipeIngredientsController;
 use App\Http\Controllers\RecipesController;
+use App\Http\Controllers\RecipeVariantsController;
 use App\Http\Controllers\RecipeTagsController;
 use App\Http\Controllers\ShoppingListEntriesController;
 use App\Http\Controllers\ShoppingListsController;
@@ -158,15 +159,24 @@ Route::middleware('auth:sanctum')->group(fn() => [
         Route::delete('/{recipe}',[RecipesController::class,'destroy']),
 
         //-----------------------------
-        //Recipe ingredients
+        //Recipe variants & ingredients
         //-----------------------------
-        Route::prefix('/{recipe}/ingredient')
+        Route::prefix('/{recipe}/variant')
             ->group(fn() => [
-                Route::get('/',[RecipeIngredientsController::class,'index']),
-                Route::post('/',[RecipeIngredientsController::class,'store']),
-                Route::get('/{ingredient}',[RecipeIngredientsController::class,'show']),
-                Route::match(['put','patch'],'/{ingredient}',[RecipeIngredientsController::class,'update']),
-                Route::delete('/{ingredient}',[RecipeIngredientsController::class,'destroy']),
+                Route::get('/',[RecipeVariantsController::class,'index']),
+                Route::post('/',[RecipeVariantsController::class,'store']),
+                Route::get('/{recipeVariant}',[RecipeVariantsController::class,'show']),
+                Route::match(['put','patch'],'/{recipeVariant}',[RecipeVariantsController::class,'update']),
+                Route::delete('/{recipeVariant}',[RecipeVariantsController::class,'destroy']),
+
+                Route::prefix('/{recipeVariant}/ingredient')
+                    ->group(fn() => [
+                        Route::get('/',[RecipeIngredientsController::class,'index']),
+                        Route::post('/',[RecipeIngredientsController::class,'store']),
+                        Route::get('/{ingredient}',[RecipeIngredientsController::class,'show']),
+                        Route::match(['put','patch'],'/{ingredient}',[RecipeIngredientsController::class,'update']),
+                        Route::delete('/{ingredient}',[RecipeIngredientsController::class,'destroy']),
+                    ]),
             ]),
     ]),
 

--- a/frontend/src/API/RecipeIngredientsAPI.js
+++ b/frontend/src/API/RecipeIngredientsAPI.js
@@ -1,17 +1,17 @@
 import RequestUtils from "@/Utils/RequestUtils";
 
 export default class RecipeIngredientsAPI {
-    static async getAll(recipeId) {
-        return await RequestUtils.apiGet(`/api/recipe/${recipeId}/ingredient`);
+    static async getAll(recipeId, variantId) {
+        return await RequestUtils.apiGet(`/api/recipe/${recipeId}/variant/${variantId}/ingredient`);
     }
 
 
-    static async get(recipeId,id) {
-        return await RequestUtils.apiGet('/api/recipe/' + recipeId + '/ingredient/' + id);
+    static async get(recipeId, variantId, id) {
+        return await RequestUtils.apiGet('/api/recipe/' + recipeId + '/variant/' + variantId + '/ingredient/' + id);
     }
 
-    static async create(recipeId,data) {
-        const result = await RequestUtils.apiPost('/api/recipe/'+recipeId+'/ingredient', data);
+    static async create(recipeId, variantId, data) {
+        const result = await RequestUtils.apiPost('/api/recipe/'+recipeId+'/variant/'+variantId+'/ingredient', data);
 
         if(result.status !== 201){
             throw new Error('RecipeIngredientsAPI.create() failed, status: ' + result.status);
@@ -20,12 +20,12 @@ export default class RecipeIngredientsAPI {
         return result;
     }
 
-    static async update(recipeId, id, data) {
-        return await RequestUtils.apiPut('/api/recipe/' + recipeId + '/ingredient/'+id, data);
+    static async update(recipeId, variantId, id, data) {
+        return await RequestUtils.apiPut('/api/recipe/' + recipeId + '/variant/' + variantId + '/ingredient/'+id, data);
     }
 
-    static async delete(recipeId,id) {
-        return await RequestUtils.apiDelete('/api/recipe/' + recipeId+ '/ingredient/' + id);
+    static async delete(recipeId, variantId, id) {
+        return await RequestUtils.apiDelete('/api/recipe/' + recipeId+ '/variant/' + variantId + '/ingredient/' + id);
     }
 
 }

--- a/frontend/src/API/RecipeVariantsAPI.js
+++ b/frontend/src/API/RecipeVariantsAPI.js
@@ -1,0 +1,19 @@
+import RequestUtils from "@/Utils/RequestUtils";
+
+export default class RecipeVariantsAPI {
+    static async getAll(recipeId) {
+        return await RequestUtils.apiGet(`/api/recipe/${recipeId}/variant`);
+    }
+
+    static async create(recipeId, data) {
+        return await RequestUtils.apiPost(`/api/recipe/${recipeId}/variant`, data);
+    }
+
+    static async update(recipeId, variantId, data) {
+        return await RequestUtils.apiPut(`/api/recipe/${recipeId}/variant/${variantId}`, data);
+    }
+
+    static async delete(recipeId, variantId) {
+        return await RequestUtils.apiDelete(`/api/recipe/${recipeId}/variant/${variantId}`);
+    }
+}

--- a/frontend/src/Components/CalendarMealEntry/CalendarMealRecipe.jsx
+++ b/frontend/src/Components/CalendarMealEntry/CalendarMealRecipe.jsx
@@ -82,7 +82,7 @@ const CalendarMealRecipe = ({meal,mealName,onClick, onEdit,selectMode, editMode,
             {mealName}
         </MealName>
         <RecipeName>
-            {meal.recipe.name}
+            {meal.recipe.name} {meal.recipe_variant && `(${meal.recipe_variant.name})`}
         </RecipeName>
         {
             selectMode && <>

--- a/frontend/src/Dialogs/IngredientCEDialog.jsx
+++ b/frontend/src/Dialogs/IngredientCEDialog.jsx
@@ -33,6 +33,7 @@ const IngredientCEDialog =
     onClose = () => {},
     editMode=false,
     editRecipeId = 0,
+    editVariantId = 0,
     editId = null
 }) => {
 
@@ -48,12 +49,12 @@ const IngredientCEDialog =
 
     useEffect(() => {
         if(editMode){
-            RecipeIngredientsAPI.get(editRecipeId,editId).then((response) => {
+            RecipeIngredientsAPI.get(editRecipeId, editVariantId, editId).then((response) => {
                 setEditIngredient(response.data.data);
                 setSelectedProduct(response.data.data.product);
             })
         }
-    }, [editMode,editId,editRecipeId,open]);
+    }, [editMode,editId,editRecipeId,editVariantId,open]);
 
     console.log(selectedProduct);
 
@@ -67,14 +68,14 @@ const IngredientCEDialog =
         validateOnChange: true,
         onSubmit: async (values) => {
             if(editMode){
-                await toast.promise(RecipeIngredientsAPI.update(editRecipeId,editId, values),{
+                await toast.promise(RecipeIngredientsAPI.update(editRecipeId, editVariantId, editId, values),{
                     loading: 'Aktualizowanie składnika...',
                     success: 'Składnik został zaktualizowany',
                     error: 'Nie udało się zaktualizować składnika'
                 });
             }else{
                 // ShoppingListsAPI.create(values)
-                await toast.promise(RecipeIngredientsAPI.create(editRecipeId,values),{
+                await toast.promise(RecipeIngredientsAPI.create(editRecipeId, editVariantId, values),{
                     loading: 'Tworzenie składnika...',
                     success: 'Składnik został utworzony',
                     error: 'Nie udało się utworzyć składnika'

--- a/frontend/src/Dialogs/RecipeSelectorDialog.jsx
+++ b/frontend/src/Dialogs/RecipeSelectorDialog.jsx
@@ -64,6 +64,9 @@ const RecipeSelectorDialog = (
 
     const [newRecipeDialogOpen,setNewRecipeDialogOpen] = useState(false);
     const [selectedTags,setSelectedTags] = useState([]);
+    const [variantDialogOpen,setVariantDialogOpen] = useState(false);
+    const [selectedRecipe,setSelectedRecipe] = useState(null);
+    const [selectedVariantId,setSelectedVariantId] = useState(null);
 
 
     const load = async () => {
@@ -103,108 +106,150 @@ const RecipeSelectorDialog = (
     },[currentPage,selectedTags,searchDebounced,needAllTags]);
 
     const handleSelect = (recipe) => {
-        onSelect(recipe);
+        const defaultVariant = recipe?.variants?.find((variant) => variant.is_default) || recipe?.variants?.[0];
+        if((recipe?.variants || []).length <= 1){
+            onSelect({recipe, variantId: defaultVariant?.id || null});
+            onClose();
+            return;
+        }
+
+        setSelectedRecipe(recipe);
+        setSelectedVariantId(defaultVariant?.id || null);
+        setVariantDialogOpen(true);
     }
 
-    return <Dialog
-        open={open}
-        TransitionComponent={Transition}
-        keepMounted
-        maxWidth={'lg'}
-        fullWidth={true}
-        onClose={onClose}
-    >
-        <DialogTitle>Wybierz Posiłek</DialogTitle>
-        <DialogContent>
-            <Container>
-                <SearchContainer>
-                    <TextField
-                        label={'Szukaj'}
-                        id={'recipe-search-input'}
-                        name={'recipe-search-input'}
-                        variant={'standard'}
-                        value={searchValue}
-                        onChange={(e) => setSearchValue(e.target.value)}
-                        fullWidth={true}
-                    />
-                    <div style={{
-                        display: 'flex',
-                        flexDirection: 'row',
-                        marginTop: '10px',
-                        justifyContent: 'space-between'
-                    }} >
-                        <div style={{width: 'calc(100% - 210px)'}} >
-                            <Multiselector
-                                title={'Tagi'}
-                                options={recipeTags}
-                                renderTags={(value, getTagProps) =>
-                                    value.map((option, index) => (
-                                        <Chip variant="outlined" label={option.name} {...getTagProps({ index })}
-                                              sx={{
-                                                  backgroundColor: option.color
-                                              }}
-                                              size={'small'}
-                                        />
-                                    ))
-                                }
-                                onChange={onTagSelect}
-                                selected={recipeTags.filter((tag) => {
-                                    return selectedTags.includes(tag.id);
-                                })}
-                            />
-                        </div>
-                        <div style={{width: '200px'}} >
-                            <FormControl variant="standard" fullWidth>
-                                <InputLabel >Wymagaj:</InputLabel>
-                                <Select
-                                    value={needAllTags}
-                                    onChange={(val) => setNeedAllTags(val.target.value)}
-                                >
-                                    <MenuItem value={1}>Wszystkich tagów</MenuItem>
-                                    <MenuItem value={0}>Dowolnego tagu</MenuItem>
-                                </Select>
-                            </FormControl>
-                        </div>
-                    </div>
-                </SearchContainer>
-
-                <RecipeCreateDialog
-                    open={newRecipeDialogOpen}
-                    onClose={(res) => {
-                        setNewRecipeDialogOpen(false);
-                        if(res){
-                            load(true);
-                        }
-                    }}
-                />
-                <Grid container spacing={2}>
-                    {
-                        recipes.map((recipe) => {
-                            return <Grid item xs={12} md={6} lg={3} xl={3} key={recipe.id}>
-                                <RecipeCard
-                                    onReload={() => load(true)}
-                                    data={recipe}
-                                    selectMode={true}
-                                    onSelect={handleSelect}
+    return <>
+        <Dialog
+            open={open}
+            TransitionComponent={Transition}
+            keepMounted
+            maxWidth={'lg'}
+            fullWidth={true}
+            onClose={onClose}
+        >
+            <DialogTitle>Wybierz Posiłek</DialogTitle>
+            <DialogContent>
+                <Container>
+                    <SearchContainer>
+                        <TextField
+                            label={'Szukaj'}
+                            id={'recipe-search-input'}
+                            name={'recipe-search-input'}
+                            variant={'standard'}
+                            value={searchValue}
+                            onChange={(e) => setSearchValue(e.target.value)}
+                            fullWidth={true}
+                        />
+                        <div style={{
+                            display: 'flex',
+                            flexDirection: 'row',
+                            marginTop: '10px',
+                            justifyContent: 'space-between'
+                        }} >
+                            <div style={{width: 'calc(100% - 210px)'}} >
+                                <Multiselector
+                                    title={'Tagi'}
+                                    options={recipeTags}
+                                    renderTags={(value, getTagProps) =>
+                                        value.map((option, index) => (
+                                            <Chip variant="outlined" label={option.name} {...getTagProps({ index })}
+                                                  sx={{
+                                                      backgroundColor: option.color
+                                                  }}
+                                                  size={'small'}
+                                            />
+                                        ))
+                                    }
+                                    onChange={onTagSelect}
+                                    selected={recipeTags.filter((tag) => {
+                                        return selectedTags.includes(tag.id);
+                                    })}
                                 />
-                            </Grid>
-                        })
-                    }
-                </Grid>
-                <Stack alignItems="center" padding={'20px'}>
-                    <Pagination
-                        count={Math.ceil(totalPages)}
-                        page={currentPage}
-                        onChange={(e,page) =>setCurrentPage(page)}
-                        color='primary'
+                            </div>
+                            <div style={{width: '200px'}} >
+                                <FormControl variant="standard" fullWidth>
+                                    <InputLabel >Wymagaj:</InputLabel>
+                                    <Select
+                                        value={needAllTags}
+                                        onChange={(val) => setNeedAllTags(val.target.value)}
+                                    >
+                                        <MenuItem value={1}>Wszystkich tagów</MenuItem>
+                                        <MenuItem value={0}>Dowolnego tagu</MenuItem>
+                                    </Select>
+                                </FormControl>
+                            </div>
+                        </div>
+                    </SearchContainer>
+
+                    <RecipeCreateDialog
+                        open={newRecipeDialogOpen}
+                        onClose={(res) => {
+                            setNewRecipeDialogOpen(false);
+                            if(res){
+                                load(true);
+                            }
+                        }}
                     />
-                </Stack>
-            </Container>
-        </DialogContent>
-        <DialogActions>
-            <Button color={'warning'} onClick={onClose}>Anuluj</Button>
-        </DialogActions>
-    </Dialog>
+                    <Grid container spacing={2}>
+                        {
+                            recipes.map((recipe) => {
+                                return <Grid item xs={12} md={6} lg={3} xl={3} key={recipe.id}>
+                                    <RecipeCard
+                                        onReload={() => load(true)}
+                                        data={recipe}
+                                        selectMode={true}
+                                        onSelect={handleSelect}
+                                    />
+                                </Grid>
+                            })
+                        }
+                    </Grid>
+                    <Stack alignItems="center" padding={'20px'}>
+                        <Pagination
+                            count={Math.ceil(totalPages)}
+                            page={currentPage}
+                            onChange={(e,page) =>setCurrentPage(page)}
+                            color='primary'
+                        />
+                    </Stack>
+                </Container>
+            </DialogContent>
+            <DialogActions>
+                <Button color={'warning'} onClick={onClose}>Anuluj</Button>
+            </DialogActions>
+        </Dialog>
+        <Dialog
+            open={variantDialogOpen}
+            onClose={() => setVariantDialogOpen(false)}
+        >
+            <DialogTitle>Wybierz wariant</DialogTitle>
+            <DialogContent>
+                <FormControl variant={'standard'} sx={{minWidth: 300}}>
+                    <InputLabel>Wariant</InputLabel>
+                    <Select
+                        value={selectedVariantId || ''}
+                        onChange={(e) => setSelectedVariantId(e.target.value)}
+                    >
+                        {(selectedRecipe?.variants || []).map((variant) => (
+                            <MenuItem value={variant.id} key={variant.id}>
+                                {variant.name} {variant.is_default ? '(domyślny)' : ''}
+                            </MenuItem>
+                        ))}
+                    </Select>
+                </FormControl>
+            </DialogContent>
+            <DialogActions>
+                <Button color={'warning'} onClick={() => setVariantDialogOpen(false)}>Anuluj</Button>
+                <Button onClick={() => {
+                    if(selectedRecipe){
+                        onSelect({recipe: selectedRecipe, variantId: selectedVariantId});
+                        setVariantDialogOpen(false);
+                        onClose();
+                    }
+                }}>Wybierz</Button>
+            </DialogActions>
+        </Dialog>
+    </>
 
 
 }

--- a/frontend/src/Views/Dashboard/CalendarView.jsx
+++ b/frontend/src/Views/Dashboard/CalendarView.jsx
@@ -278,13 +278,14 @@ const CalendarView = () => {
         setSelectedEditData(null);
     }
 
-    const selectRecipe = async (recipe) => {
+    const selectRecipe = async ({recipe, variantId}) => {
         console.log('RECIPE',recipe);
         await toast.promise(CalendarEntriesAPI.create({
             "type" :"from_recipe",
             "date": selectedEditData.date,
             "meal_order": selectedEditData.mealNo,
-            "recipe_id": recipe.id
+            "recipe_id": recipe.id,
+            "recipe_variant_id": variantId
         }),{
             loading: 'Dodawanie przepisu...',
             success: 'Pomyślnie dodano przepis',

--- a/frontend/src/Views/Dashboard/RecipeEditView.jsx
+++ b/frontend/src/Views/Dashboard/RecipeEditView.jsx
@@ -4,7 +4,7 @@ import {useEffect, useRef, useState} from "react";
 import ProductsAPI from "@/API/ProductsAPI";
 import toast from "react-hot-toast";
 import ProductAPI from "@/API/RecipesAPI";
-import {Box, Chip, Grid, Tab, Tabs, TextField} from "@mui/material";
+import {Box, Button, Chip, FormControl, Grid, InputLabel, MenuItem, Select, Tab, Tabs, TextField} from "@mui/material";
 import placeholderImage from "@/Assets/placeholder.png";
 import RecipesAPI from "@/API/RecipesAPI";
 import NetworkUtils from "@/Utils/NetworkUtils";
@@ -21,6 +21,7 @@ import {useSelector} from "react-redux";
 import recipeTagsReducer, {requestRecipeTags} from "@/Store/Reducers/RecipeTagsReducer";
 import store from "@/Store/store";
 import RecipeIngredientsAPI from "@/API/RecipeIngredientsAPI";
+import RecipeVariantsAPI from "@/API/RecipeVariantsAPI";
 
 const Container = styled.div`
   width: calc(100% - 100px);
@@ -90,11 +91,24 @@ const RecipeEditView = () => {
     const [stepDialogStartText, setStepDialogStartText] = useState('');
     const [ingredientDialogOpen, setIngredientDialogOpen] = useState(false);
     const [ingredientDialogEdit, setIngredientDialogEdit] = useState(0);
+    const [variants,setVariants] = useState([]);
+    const [selectedVariantId,setSelectedVariantId] = useState(null);
+    const [variantName,setVariantName] = useState('');
+    const [newVariantName,setNewVariantName] = useState('');
     const [newImage, setNewImage] = useState({
         selected: false,
         url: '',
         file: null
     });
+
+    const syncVariants = (recipeData) => {
+        const recipeVariants = recipeData?.variants || [];
+        setVariants(recipeVariants);
+
+        const defaultVariant = recipeVariants.find((variant) => variant.is_default) || recipeVariants[0];
+        setSelectedVariantId(defaultVariant?.id || null);
+        setVariantName(defaultVariant?.name || '');
+    }
 
     const load = async () => {
         store.dispatch(requestRecipeTags());
@@ -110,6 +124,7 @@ const RecipeEditView = () => {
         let {data} = response.data;
 
         setProduct(data);
+        syncVariants(data);
 
         console.log('LOAD');
         setOldImagePath(NetworkUtils.fixBackendUrl(data?.image) || placeholderImage);
@@ -136,6 +151,82 @@ const RecipeEditView = () => {
     useEffect(() => {
         updateImage();
     }, [newImage]);
+
+    const selectedVariant = variants.find((variant) => variant.id === selectedVariantId) || null;
+
+    const handleVariantChange = (value) => {
+        setSelectedVariantId(value);
+        const variant = variants.find((variant) => variant.id === value);
+        setVariantName(variant?.name || '');
+    }
+
+    const createVariant = async () => {
+        if(!newVariantName.trim()){
+            toast.error('Podaj nazwę wariantu');
+            return;
+        }
+
+        await toast.promise(RecipeVariantsAPI.create(id,{
+            name: newVariantName
+        }),{
+            loading: 'Dodawanie wariantu...',
+            success: 'Dodano wariant',
+            error: 'Nie udało się dodać wariantu'
+        });
+
+        setNewVariantName('');
+        await load();
+    }
+
+    const saveVariantName = async () => {
+        if(!selectedVariantId){
+            toast.error('Wybierz wariant');
+            return;
+        }
+
+        await toast.promise(RecipeVariantsAPI.update(id, selectedVariantId,{
+            name: variantName
+        }),{
+            loading: 'Aktualizowanie wariantu...',
+            success: 'Wariant został zaktualizowany',
+            error: 'Nie udało się zaktualizować wariantu'
+        });
+
+        await load();
+    }
+
+    const setDefaultVariant = async () => {
+        if(!selectedVariantId){
+            toast.error('Wybierz wariant');
+            return;
+        }
+
+        await toast.promise(RecipeVariantsAPI.update(id, selectedVariantId,{
+            is_default: true
+        }),{
+            loading: 'Ustawianie wariantu domyślnego...',
+            success: 'Ustawiono wariant domyślny',
+            error: 'Nie udało się ustawić wariantu domyślnego'
+        });
+
+        await load();
+    }
+
+    const deleteVariant = async () => {
+        if(!selectedVariantId){
+            toast.error('Wybierz wariant');
+            return;
+        }
+
+        await toast.promise(RecipeVariantsAPI.delete(id, selectedVariantId),{
+            loading: 'Usuwanie wariantu...',
+            success: 'Usunięto wariant',
+            error: 'Nie udało się usunąć wariantu'
+        });
+
+        setSelectedVariantId(null);
+        await load();
+    }
 
     const formik = useFormik({
         initialValues: {
@@ -233,6 +324,10 @@ const RecipeEditView = () => {
             'label': 'Dodaj składnik',
             'icon': <Add />,
             'onClick': async () => {
+                if(!selectedVariantId){
+                    toast.error('Wybierz wariant, aby dodać składniki');
+                    return;
+                }
                 setIngredientDialogOpen(true);
                 setIngredientDialogEdit(0);
             }
@@ -245,6 +340,10 @@ const RecipeEditView = () => {
             'label': 'Edytuj',
             'icon': <Edit />,
             'onClick': async ({id}) =>{
+                if(!selectedVariantId){
+                    toast.error('Wybierz wariant');
+                    return;
+                }
                 setIngredientDialogOpen(true);
                 setIngredientDialogEdit(id);
             }
@@ -253,7 +352,7 @@ const RecipeEditView = () => {
             'label': 'Usuń',
             'icon': <Delete color={'error'} />,
             'onClick': async ({id: rowId}) => {
-                toast.promise(RecipeIngredientsAPI.delete(id,rowId),{
+                toast.promise(RecipeIngredientsAPI.delete(id, selectedVariantId, rowId),{
                     loading: 'usuwania składnika...',
                     success: 'Składnik został usunięty',
                     error: 'Nie udało się usunąć składnika'
@@ -304,6 +403,7 @@ const RecipeEditView = () => {
             editId={ingredientDialogEdit}
             editMode={ingredientDialogEdit > 0}
             editRecipeId={id}
+            editVariantId={selectedVariantId}
             open={ingredientDialogOpen}
             onClose={(success) => {
                 setIngredientDialogOpen(false);
@@ -313,7 +413,7 @@ const RecipeEditView = () => {
             }}
         />
         <h2>{
-            isLoading ? 'Ładowanie...' : product.name + ' ('+Math.round(product.calories_per_serving)+' kcal)'
+            isLoading ? 'Ładowanie...' : product.name + ' ('+Math.round(selectedVariant?.calories_per_serving || product.calories_per_serving)+' kcal)'
         }</h2>
         <FAB
             icon={<Save/>}
@@ -392,6 +492,51 @@ const RecipeEditView = () => {
                                 />
                             </Grid>
                             <Grid item xs={12}>
+                                <FormControl fullWidth variant={'standard'}>
+                                    <InputLabel>Wariant</InputLabel>
+                                    <Select
+                                        value={selectedVariantId || ''}
+                                        onChange={(val) => handleVariantChange(val.target.value)}
+                                    >
+                                        {variants.map((variant) => (
+                                            <MenuItem key={variant.id} value={variant.id}>
+                                                {variant.name} {variant.is_default ? '(domyślny)' : ''}
+                                            </MenuItem>
+                                        ))}
+                                    </Select>
+                                </FormControl>
+                            </Grid>
+                            <Grid item xs={12} lg={6}>
+                                <TextField
+                                    variant={'standard'}
+                                    name={'variant_name'}
+                                    label={'Nazwa wybranego wariantu'}
+                                    value={variantName}
+                                    onChange={(e) => setVariantName(e.target.value)}
+                                    fullWidth
+                                />
+                            </Grid>
+                            <Grid item xs={12} lg={6}>
+                                <div style={{display: 'flex', flexDirection: 'row', gap: '10px', flexWrap: 'wrap'}}>
+                                    <Button variant={'contained'} onClick={saveVariantName}>Zapisz nazwę</Button>
+                                    <Button variant={'outlined'} onClick={setDefaultVariant}>Ustaw domyślny</Button>
+                                    <Button variant={'outlined'} color={'error'} onClick={deleteVariant}>Usuń wariant</Button>
+                                </div>
+                            </Grid>
+                            <Grid item xs={12} lg={6}>
+                                <TextField
+                                    variant={'standard'}
+                                    name={'new_variant_name'}
+                                    label={'Nazwa nowego wariantu'}
+                                    value={newVariantName}
+                                    onChange={(e) => setNewVariantName(e.target.value)}
+                                    fullWidth
+                                />
+                            </Grid>
+                            <Grid item xs={12} lg={6}>
+                                <Button variant={'contained'} onClick={createVariant}>Dodaj wariant</Button>
+                            </Grid>
+                            <Grid item xs={12}>
                                 <Multiselector
                                     title={'Tagi'}
                                     options={recipeTags}
@@ -457,7 +602,7 @@ const RecipeEditView = () => {
                     tools={ingredientsTools}
                     inlineTools={ingredientsInlineTools}
                     searchBar={true}
-                    data={product?.ingredients?.map((ingredient) =>{
+                    data={selectedVariant?.ingredients?.map((ingredient) =>{
                         return {
                             id: ingredient.id,
                             name: ingredient.product.name,

--- a/frontend/src/Views/Dashboard/RecipeView.jsx
+++ b/frontend/src/Views/Dashboard/RecipeView.jsx
@@ -7,7 +7,7 @@ import NetworkUtils from "@/Utils/NetworkUtils";
 import kcalImage from '@/Assets/kcal.png';
 import foodRationImage from '@/Assets/food_ration.png';
 import timeImage from '@/Assets/time.png';
-import {Grid, IconButton} from "@mui/material";
+import {FormControl, Grid, IconButton, InputLabel, MenuItem, Select} from "@mui/material";
 import {EntryRawProductContent} from "@/Components/ShoppingListEntry/ShoppingListEntry";
 import NumberInput from "@/Components/NumberInput/NumberInput";
 import VerticalLinearStepper from "@/Components/RecipeSteps/RecipeSteps";
@@ -82,6 +82,7 @@ const RecipeView = () => {
     const [recipe,setRecipe] = useState(null);
     const [isLoading,setIsLoading] = useState(true);
     const [showPerPortion,setShowPerPortion] = useState(1);
+    const [selectedVariantId,setSelectedVariantId] = useState(null);
 
     const navigate = useNavigate();
 
@@ -114,19 +115,26 @@ const RecipeView = () => {
         const {data} = response.data;
 
         setRecipe(data);
+        const defaultVariant = data?.variants?.find((variant) => variant.is_default) || data?.variants?.[0];
+        setSelectedVariantId(defaultVariant?.id || null);
         setShowPerPortion(data.serving_amount);
 
         setIsLoading(false);
     }
 
+    const selectedVariant = recipe?.variants?.find((variant) => variant.id === selectedVariantId)
+        || recipe?.variants?.find((variant) => variant.is_default)
+        || recipe?.variants?.[0];
+
     let porMulti = (showPerPortion || 1);
+    const caloriesPerServing = selectedVariant?.calories_per_serving || recipe?.calories_per_serving;
 
     const topData = [
         {
             image: kcalImage,
             value: <>
-                {Math.round(recipe?.calories_per_serving * porMulti) || 0} kalorii <br />
-                {Math.round(recipe?.calories_per_serving)} na porcję
+                {Math.round((caloriesPerServing || 0) * porMulti) || 0} kalorii <br />
+                {Math.round(caloriesPerServing || 0)} na porcję
             </>
         },
         {
@@ -180,6 +188,26 @@ const RecipeView = () => {
                 ))
             }
         </Grid>
+        <div style={{
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'flex-start',
+            padding: '20px 0'
+        }}>
+            <FormControl variant={'standard'} sx={{minWidth: 200}}>
+                <InputLabel>Wariant</InputLabel>
+                <Select
+                    value={selectedVariantId || ''}
+                    onChange={(e) => setSelectedVariantId(e.target.value)}
+                >
+                    {(recipe?.variants || []).map((variant) => (
+                        <MenuItem value={variant.id} key={variant.id}>
+                            {variant.name} {variant.is_default ? '(domyślny)' : ''}
+                        </MenuItem>
+                    ))}
+                </Select>
+            </FormControl>
+        </div>
         <div
             style={{
                 display: 'flex',
@@ -219,7 +247,7 @@ const RecipeView = () => {
                     }}
                 >
                     {
-                        recipe?.ingredients.map(ingredient => (
+                        (selectedVariant?.ingredients || []).map(ingredient => (
                             //<li>{ingredient.product.name} - {ingredient.amount_in_unit} {ingredient.unit.name}</li>
                             <div style={{
                                 padding: '4px'


### PR DESCRIPTION
## Summary
- add recipe variants with dedicated model, migration, and ingredient relationships
- expose variant management APIs and allow selecting variants when adding recipes to the calendar
- update recipe views to manage variants and show variant-specific ingredients and calories

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a2cf4c5fc8323bfc8e783c1186055)