### PR TITLE
Redesign frontend with modern layout and custom MUI look

### DIFF
--- a/frontend/src/App/GlobalStyles/index.scss
+++ b/frontend/src/App/GlobalStyles/index.scss
@@ -1,5 +1,5 @@
 // Fonts
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Montserrat:wght@400;700&display=swap');
 
 // Variables
 @import 'variables';
@@ -7,13 +7,16 @@
 
 
 * {
-  font-family: 'Montserrat', sans-serif;
+  font-family: 'Inter', 'Montserrat', sans-serif;
   padding: 0;
   margin: 0;
+  box-sizing: border-box;
 }
 
 body {
   overflow: hidden;
+  background: #f1f5f9;
+  color: #0f172a;
 }
 
 #root {
@@ -21,4 +24,3 @@ body {
   height: 100vh;
   overflow: auto;
 }
-

--- a/frontend/src/Components/MiniNavItem/MiniNavItem.jsx
+++ b/frontend/src/Components/MiniNavItem/MiniNavItem.jsx
@@ -3,13 +3,17 @@ import {Icon} from "@iconify/react/offline";
 
 
 const Item = styled(Icon)`
-    width: 24px;
-    height: 24px;
-    padding: 4px;
-    color: #A6A6A6;
+    width: 22px;
+    height: 22px;
+    padding: 6px;
+    color: #cbd5e1;
     margin: 0px 8px;
+    border-radius: 10px;
+    transition: all 0.15s ease-in-out;
 
     &:hover {
+        color: #f8fafc;
+        background: rgba(148, 163, 184, 0.22);
         cursor: pointer;
     }
 

--- a/frontend/src/Components/NavItem/NavItem.jsx
+++ b/frontend/src/Components/NavItem/NavItem.jsx
@@ -4,33 +4,37 @@ import {Icon} from "@iconify/react/offline";
 
 
 const Container = styled.div`
-    background-color: #2B2B2B;
-    border-radius: 8px;
+    border-radius: 12px;
     border: 1px solid transparent;
-    max-width: 210px;
-    margin: 6px auto;
+    max-width: 222px;
+    margin: 8px auto;
     display: flex;
     flex-direction: row;
+    align-items: center;
+    transition: all 0.15s ease-in-out;
 
     &:hover {
-        border: 1px solid #494949;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(148, 163, 184, 0.12);
         cursor: pointer;
+        transform: translateX(2px);
     }
 
     @media (max-width: 768px) {
-        max-width: 300px;
-        margin: 20px auto;
+        max-width: 340px;
+        margin: 12px auto;
     }
 `;
 
 const Title = styled.p`
-    color: #bebebe;
+    color: #94a3b8;
     font-size: 15px;
-    padding: 12px 0px;
+    padding: 12px 0;
+    font-weight: 600;
 
     @media (max-width: 768px) {
-        font-size: 20px;
-        padding: 16px 0px;
+        font-size: 19px;
+        padding: 14px 0;
     }
 `;
 
@@ -38,7 +42,7 @@ const StyledIcon = styled(Icon)`
     width: 24px;
     height: 24px;
     padding: 8px 16px;
-    color: #494949;
+    color: #64748b;
 
     @media (max-width: 768px) {
         width: 32px;
@@ -63,10 +67,14 @@ const NavItem = (
          navigate(url);
      }
 
-     const color = match ? '#FACC2C' : '#494949';
+     const color = match ? '#e2e8f0' : '#64748b';
+     const containerStyle = match ? {
+         background: 'linear-gradient(90deg, rgba(14, 165, 233, 0.35) 0%, rgba(59, 130, 246, 0.22) 100%)',
+         border: '1px solid rgba(56, 189, 248, 0.38)',
+     } : {};
 
     return (
-        <Container onClick={handleClick} >
+        <Container onClick={handleClick} style={containerStyle} >
             <StyledIcon style={{color}} icon={icon} />
             <Title style={{color}} >{name}</Title>
         </Container>

--- a/frontend/src/Components/Navigation/Navigation.jsx
+++ b/frontend/src/Components/Navigation/Navigation.jsx
@@ -23,12 +23,15 @@ import {Icon} from "@iconify/react/offline";
 
 
 const Container = styled.div`
-    background-color: #2B2B2B;
+    background: linear-gradient(180deg, #0f172a 0%, #111827 100%);
     width: 250px;
     height: 100vh;
     transition: left 0.2s ease-in;
-    z-index: 1000; 
-
+    z-index: 1000;
+    border-right: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: 10px 0 30px rgba(2, 6, 23, 0.35);
+    display: flex;
+    flex-direction: column;
 
     @media (max-width: 768px) {
         width: 100vw;
@@ -37,16 +40,16 @@ const Container = styled.div`
 `;
 
 const Title = styled.h2`
-    color: #FACC2C;
-    font-weight: bold;
-    font-size: 32px;
-    padding-top: 5px;
+    color: #e2e8f0;
+    font-weight: 700;
+    font-size: 30px;
+    padding-top: 14px;
     text-align: center;
-    letter-spacing: 4px;
-    height: 45px;
+    letter-spacing: 1px;
+    height: 58px;
 
     @media (max-width: 768px) {
-    padding: 30px 0px;
+    padding: 26px 0px 20px 0;
     }
 `;
 
@@ -54,11 +57,13 @@ const MiniNav = styled.div`
     display: flex;
     justify-content: center;
     flex-direction: row;
-    width: 100%;
-    height: 32px;
-    background-color: #494949;
-    margin-bottom: 10px;
-
+    width: calc(100% - 28px);
+    height: 44px;
+    margin: 0 auto 12px auto;
+    background: rgba(148, 163, 184, 0.15);
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    border-radius: 14px;
+    backdrop-filter: blur(6px);
 
     @media (max-width: 768px) {
         height: 50px;
@@ -67,16 +72,12 @@ const MiniNav = styled.div`
 
 const ExitIcon = styled(Icon)`
     position: absolute;
-    top: 25px;
-    left: 25px;
-    width: 50px;
-    height: 50px;
-    color: #FACC2C;
+    top: 20px;
+    left: 16px;
+    width: 42px;
+    height: 42px;
+    color: #cbd5e1;
 `;
-
-
-
-
 
 const Navigation = ({
     open,
@@ -115,7 +116,7 @@ const Navigation = ({
                 <MiniNavItem icon={cogIcon} onClick={onSettingsClick} />
                 <MiniNavItem icon={baselineMeetingRoom} onClick={onLogoutClick} />
             </MiniNav>
-            <nav>
+            <nav style={{ paddingBottom: '16px', overflowY: 'auto' }}>
                 <NavItem name={'Kalendarz'} icon={calendarIcon} url={'/kalendarz'} />
                 <NavItem name={'Lista zakupów'} icon={basketOutline} url={'/lista-zakupow'} />
                 <NavItem name={'Przepisy'} icon={receiptText} url={'/przepisy'} />

--- a/frontend/src/Components/TopBar/TopBar.jsx
+++ b/frontend/src/Components/TopBar/TopBar.jsx
@@ -9,10 +9,17 @@ import {useNavigate} from "react-router-dom";
 const Container = styled.div`
     display: flex;
     flex-direction: row;
+    align-items: center;
     width: 100%;
-    height: 50px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-    border-bottom: 1px solid #bcbaba;
+    height: 64px;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+    border-bottom: 1px solid #e2e8f0;
+    background: rgba(255, 255, 255, 0.9);
+    backdrop-filter: blur(12px);
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    border-radius: 0 0 16px 16px;
 
     @media (max-width: 768px) {
         height: 70px;
@@ -20,20 +27,26 @@ const Container = styled.div`
 `;
 
 const OpenIcon = styled(Icon)`
-    margin: 10px;
-    width: 50px;
-    height: 50px;
-    color: #545454;
+    margin: 10px 12px;
+    width: 34px;
+    height: 34px;
+    color: #334155;
+    padding: 6px;
+    border-radius: 12px;
+
+    &:hover {
+        background: #e2e8f0;
+        cursor: pointer;
+    }
 `;
 
 const Logo = styled.p`
     width: calc(100vw - 140px);
-    padding-top: 16px;
     text-align: center;
-    color: #FACC2C;
-    font-weight: bold;
-    font-size: 30px;
-    letter-spacing: 2px;
+    color: #0f172a;
+    font-weight: 700;
+    font-size: 28px;
+    letter-spacing: 0.5px;
 `;
 
 const TopBar = ({

--- a/frontend/src/Theme/theme.js
+++ b/frontend/src/Theme/theme.js
@@ -2,18 +2,119 @@ import { createTheme } from '@mui/material/styles';
 
 const theme = createTheme({
     palette: {
+        mode: 'light',
         primary: {
-            light: 'rgb(250, 204, 44)',
-            main: 'rgb(250, 204, 44)',
-            dark: 'rgb(234,190,30)',
-            contrastText: '#fff',
+            light: '#7dd3fc',
+            main: '#0ea5e9',
+            dark: '#0369a1',
+            contrastText: '#ffffff',
         },
-       /* secondary: {
-            light: '#ff7961',
-            main: '#f44336',
-            dark: '#ba000d',
-            contrastText: '#000',
-        },*/
+        secondary: {
+            light: '#a78bfa',
+            main: '#8b5cf6',
+            dark: '#6d28d9',
+            contrastText: '#ffffff',
+        },
+        background: {
+            default: '#f4f7fb',
+            paper: '#ffffff',
+        },
+        text: {
+            primary: '#0f172a',
+            secondary: '#475569',
+        }
+    },
+    shape: {
+        borderRadius: 14,
+    },
+    typography: {
+        fontFamily: '"Inter", "Montserrat", "Segoe UI", sans-serif',
+    },
+    components: {
+        MuiPaper: {
+            styleOverrides: {
+                root: {
+                    borderRadius: 16,
+                    border: '1px solid #e2e8f0',
+                    boxShadow: '0 10px 30px rgba(15, 23, 42, 0.08)',
+                    backgroundImage: 'none',
+                },
+            },
+        },
+        MuiCard: {
+            styleOverrides: {
+                root: {
+                    borderRadius: 16,
+                    border: '1px solid #e2e8f0',
+                    boxShadow: '0 10px 30px rgba(15, 23, 42, 0.08)',
+                },
+            },
+        },
+        MuiDialog: {
+            styleOverrides: {
+                paper: {
+                    borderRadius: 18,
+                },
+            },
+        },
+        MuiButton: {
+            defaultProps: {
+                disableElevation: true,
+            },
+            styleOverrides: {
+                root: {
+                    borderRadius: 12,
+                    textTransform: 'none',
+                    fontWeight: 600,
+                    paddingInline: '16px',
+                },
+            },
+        },
+        MuiIconButton: {
+            styleOverrides: {
+                root: {
+                    borderRadius: 12,
+                },
+            },
+        },
+        MuiChip: {
+            styleOverrides: {
+                root: {
+                    borderRadius: 10,
+                },
+            },
+        },
+        MuiTextField: {
+            defaultProps: {
+                variant: 'outlined',
+            },
+        },
+        MuiOutlinedInput: {
+            styleOverrides: {
+                root: {
+                    borderRadius: 12,
+                    backgroundColor: '#ffffff',
+                    '& .MuiOutlinedInput-notchedOutline': {
+                        borderColor: '#dbe3ef',
+                    },
+                    '&:hover .MuiOutlinedInput-notchedOutline': {
+                        borderColor: '#a5b4fc',
+                    },
+                    '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                        borderWidth: '1px',
+                        borderColor: '#0ea5e9',
+                    },
+                },
+            },
+        },
+        MuiTabs: {
+            styleOverrides: {
+                indicator: {
+                    height: 3,
+                    borderRadius: 999,
+                },
+            },
+        },
     },
 });
 

--- a/frontend/src/Views/DashboardView.jsx
+++ b/frontend/src/Views/DashboardView.jsx
@@ -4,13 +4,12 @@ import {useEffect, useState} from "react";
 import styled from "styled-components";
 import TopBar from "@/Components/TopBar/TopBar";
 import {useMediaQuery} from "@/Hooks/useMediaQuery";
-import ShoppingListsAPI from "@/API/ShoppingListsAPI";
 
 
 const Container = styled.div`
     width: calc(100vw - 250px);
     height: 100vh;
-    background-color: #F3F3F3;
+    background: radial-gradient(circle at top, #f8fbff 0%, #f1f5f9 45%, #eef2f7 100%);
 
     @media (max-width: 768px) {
         width: 100vw;
@@ -28,6 +27,8 @@ const Flex = styled.div`
 const OutletContainer = styled.div`
   width: 100%;
   overflow: auto;
+  padding: 12px;
+  box-sizing: border-box;
 `;
 
 const DashboardView = () => {
@@ -53,7 +54,7 @@ const DashboardView = () => {
                 <TopBar onOpen={onNavClick} />
                 <OutletContainer
                     style={{
-                        height: mobile ? 'calc(100% - 71px)' : 'calc(100% - 51px)'
+                        height: mobile ? 'calc(100% - 71px)' : 'calc(100% - 65px)'
                     }}
                 >
                     <Outlet />


### PR DESCRIPTION
### Motivation
- Refresh the app UI to a more modern, app-like visual language while preserving all existing features and interaction logic. 
- Keep MUI components in place but override their visuals so the app no longer reads as classical Material Design. 
- Improve overall typography, spacing and surface styling for better perceived hierarchy and clarity.

### Description
- Extended the MUI theme in `frontend/src/Theme/theme.js` with a new palette, `mode`, `shape`, `typography` and `components` `styleOverrides` for `Paper`, `Card`, `Dialog`, `Button`, `OutlinedInput`, `Tabs` and others to produce rounded, elevated, and less "material" visuals. 
- Updated global styles in `frontend/src/App/GlobalStyles/index.scss` to add `Inter` as the primary font, `box-sizing` reset, and a neutral background and base text color. 
- Reworked the dashboard shell and content spacing in `frontend/src/Views/DashboardView.jsx` to use a soft radial background, padding for content and adjusted top bar offsets. 
- Restyled sidebar and related components in `frontend/src/Components/Navigation/Navigation.jsx`, `frontend/src/Components/NavItem/NavItem.jsx`, `frontend/src/Components/MiniNavItem/MiniNavItem.jsx` and `frontend/src/Components/TopBar/TopBar.jsx` to use a dark gradient sidebar, glass-like mini-nav, refined hover/active states, sticky blurred top bar and updated icon/title treatments without changing navigation behavior.

### Testing
- Ran `npm run build` in the `frontend` directory and the production build completed successfully. 
- The build emitted pre-existing ESLint warnings unrelated to the visual changes and no new build errors were introduced. 
- No automated unit tests were added or changed; visual changes were validated by building the frontend artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1cf1bed083238d2e700740336885)