### PR TITLE
feat(frontend): modernize dashboard layout and visual theme

### DIFF
--- a/frontend/src/App/GlobalStyles/index.scss
+++ b/frontend/src/App/GlobalStyles/index.scss
@@ -14,6 +14,8 @@
 
 body {
   overflow: hidden;
+  background-color: #f4f7ff;
+  color: #1e2447;
 }
 
 #root {
@@ -22,3 +24,12 @@ body {
   overflow: auto;
 }
 
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: #c8d2ff;
+  border-radius: 10px;
+}

--- a/frontend/src/Components/MiniNavItem/MiniNavItem.jsx
+++ b/frontend/src/Components/MiniNavItem/MiniNavItem.jsx
@@ -3,20 +3,25 @@ import {Icon} from "@iconify/react/offline";
 
 
 const Item = styled(Icon)`
-    width: 24px;
-    height: 24px;
-    padding: 4px;
-    color: #A6A6A6;
-    margin: 0px 8px;
+    width: 22px;
+    height: 22px;
+    padding: 10px;
+    color: #dce2ff;
+    border-radius: 10px;
+    margin: 0;
+    background: rgba(255, 255, 255, 0.07);
+    border: 1px solid rgba(221, 229, 255, 0.2);
+    transition: all 0.2s ease-in-out;
 
     &:hover {
         cursor: pointer;
+        transform: translateY(-1px);
+        background: rgba(255, 255, 255, 0.16);
     }
 
     @media (max-width: 768px) {
-        width: 40px;
-        height: 40px;
-        padding: 5px;
+        width: 26px;
+        height: 26px;
     }
 
 `;

--- a/frontend/src/Components/NavItem/NavItem.jsx
+++ b/frontend/src/Components/NavItem/NavItem.jsx
@@ -4,46 +4,51 @@ import {Icon} from "@iconify/react/offline";
 
 
 const Container = styled.div`
-    background-color: #2B2B2B;
-    border-radius: 8px;
+    background-color: transparent;
+    border-radius: 12px;
     border: 1px solid transparent;
-    max-width: 210px;
-    margin: 6px auto;
+    max-width: 100%;
+    margin: 4px 8px;
     display: flex;
     flex-direction: row;
+    align-items: center;
+    transition: all 0.2s ease-in;
 
     &:hover {
-        border: 1px solid #494949;
+        border: 1px solid rgba(176, 190, 255, 0.45);
+        background: rgba(255, 255, 255, 0.08);
         cursor: pointer;
+        transform: translateX(2px);
     }
 
     @media (max-width: 768px) {
-        max-width: 300px;
-        margin: 20px auto;
+        margin: 8px auto;
+        max-width: 420px;
     }
 `;
 
 const Title = styled.p`
-    color: #bebebe;
+    color: #a8b3ed;
     font-size: 15px;
-    padding: 12px 0px;
+    padding: 10px 0;
+    font-weight: 600;
 
     @media (max-width: 768px) {
-        font-size: 20px;
-        padding: 16px 0px;
+        font-size: 18px;
+        padding: 14px 0;
     }
 `;
 
 const StyledIcon = styled(Icon)`
-    width: 24px;
-    height: 24px;
-    padding: 8px 16px;
-    color: #494949;
+    width: 22px;
+    height: 22px;
+    padding: 10px 14px;
+    color: #8d9af0;
 
     @media (max-width: 768px) {
-        width: 32px;
-        height: 32px;
-        padding: 10px 16px;
+        width: 24px;
+        height: 24px;
+        padding: 14px 16px;
     }
 
 `;
@@ -63,12 +68,12 @@ const NavItem = (
          navigate(url);
      }
 
-     const color = match ? '#FACC2C' : '#494949';
+    const color = match ? '#f2f4ff' : '#8d9af0';
 
     return (
-        <Container onClick={handleClick} >
+        <Container onClick={handleClick} style={match ? { background: 'linear-gradient(90deg, rgba(91,108,255,0.35), rgba(59,198,173,0.18))', borderColor: 'rgba(170, 184, 255, 0.55)' } : {}}>
             <StyledIcon style={{color}} icon={icon} />
-            <Title style={{color}} >{name}</Title>
+            <Title style={{color}}>{name}</Title>
         </Container>
     )
 

--- a/frontend/src/Components/Navigation/Navigation.jsx
+++ b/frontend/src/Components/Navigation/Navigation.jsx
@@ -23,55 +23,68 @@ import {Icon} from "@iconify/react/offline";
 
 
 const Container = styled.div`
-    background-color: #2B2B2B;
-    width: 250px;
+    background: linear-gradient(165deg, #121631 0%, #171d42 45%, #1e2755 100%);
+    border-right: 1px solid rgba(255, 255, 255, 0.08);
+    width: 280px;
     height: 100vh;
     transition: left 0.2s ease-in;
-    z-index: 1000; 
+    z-index: 1000;
+    box-shadow: 10px 0 30px rgba(12, 16, 40, 0.25);
+    box-sizing: border-box;
+    padding: 20px 16px 16px;
 
 
     @media (max-width: 768px) {
         width: 100vw;
+        padding-top: 64px;
     }
 
 `;
 
 const Title = styled.h2`
-    color: #FACC2C;
+    color: #f5f7ff;
     font-weight: bold;
-    font-size: 32px;
-    padding-top: 5px;
-    text-align: center;
-    letter-spacing: 4px;
-    height: 45px;
+    font-size: 34px;
+    text-align: left;
+    letter-spacing: 2px;
+    height: 48px;
+    margin-bottom: 10px;
+    padding-left: 8px;
 
     @media (max-width: 768px) {
-    padding: 30px 0px;
+      text-align: center;
+      padding: 0;
     }
 `;
 
 const MiniNav = styled.div`
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     flex-direction: row;
-    width: 100%;
-    height: 32px;
-    background-color: #494949;
-    margin-bottom: 10px;
+    gap: 10px;
+    width: calc(100% - 16px);
+    margin: 0 8px 18px;
+    padding: 10px;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(6px);
 
 
     @media (max-width: 768px) {
-        height: 50px;
+        justify-content: center;
     }
 `;
 
 const ExitIcon = styled(Icon)`
     position: absolute;
-    top: 25px;
-    left: 25px;
-    width: 50px;
-    height: 50px;
-    color: #FACC2C;
+    top: 14px;
+    left: 14px;
+    width: 40px;
+    height: 40px;
+    color: #d6ddff;
+    padding: 6px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.08);
 `;
 
 

--- a/frontend/src/Components/TopBar/TopBar.jsx
+++ b/frontend/src/Components/TopBar/TopBar.jsx
@@ -8,31 +8,39 @@ import {useNavigate} from "react-router-dom";
 
 const Container = styled.div`
     display: flex;
-    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
     width: 100%;
-    height: 50px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-    border-bottom: 1px solid #bcbaba;
+    height: 64px;
+    box-shadow: 0 8px 24px rgba(32, 48, 120, 0.08);
+    border-bottom: 1px solid #e5eafb;
+    background: rgba(255, 255, 255, 0.8);
+    backdrop-filter: blur(8px);
+    box-sizing: border-box;
+    padding: 0 18px;
 
     @media (max-width: 768px) {
         height: 70px;
+        padding: 0 12px;
     }
 `;
 
 const OpenIcon = styled(Icon)`
-    margin: 10px;
-    width: 50px;
-    height: 50px;
-    color: #545454;
+    width: 28px;
+    height: 28px;
+    color: #4d5ab3;
+    padding: 10px;
+    border-radius: 12px;
+    background: #eef2ff;
+    border: 1px solid #d8e0ff;
 `;
 
 const Logo = styled.p`
-    width: calc(100vw - 140px);
-    padding-top: 16px;
+    flex: 1;
     text-align: center;
-    color: #FACC2C;
+    color: #1f295f;
     font-weight: bold;
-    font-size: 30px;
+    font-size: 24px;
     letter-spacing: 2px;
 `;
 
@@ -47,9 +55,12 @@ const TopBar = ({
 
     return (
         <Container>
-            {isMobile && <>
+            {isMobile ? <>
                 <OpenIcon icon={menuIcon} onClick={onOpen} />
                 <Logo>Fridgy</Logo>
+                <OpenIcon icon={barcodeScan} onClick={() => navigate('/skaner')} />
+            </> : <>
+                <Logo style={{ textAlign: 'left', fontSize: '22px' }}>Witaj w Fridgy 👋</Logo>
                 <OpenIcon icon={barcodeScan} onClick={() => navigate('/skaner')} />
             </>}
 

--- a/frontend/src/Theme/theme.js
+++ b/frontend/src/Theme/theme.js
@@ -2,18 +2,76 @@ import { createTheme } from '@mui/material/styles';
 
 const theme = createTheme({
     palette: {
+        mode: 'light',
         primary: {
-            light: 'rgb(250, 204, 44)',
-            main: 'rgb(250, 204, 44)',
-            dark: 'rgb(234,190,30)',
-            contrastText: '#fff',
+            light: '#8EA3FF',
+            main: '#5B6CFF',
+            dark: '#4452CC',
+            contrastText: '#FFFFFF',
         },
-       /* secondary: {
-            light: '#ff7961',
-            main: '#f44336',
-            dark: '#ba000d',
-            contrastText: '#000',
-        },*/
+        secondary: {
+            light: '#7EE5D3',
+            main: '#3BC6AD',
+            dark: '#2D9B87',
+            contrastText: '#FFFFFF',
+        },
+        background: {
+            default: '#F4F7FF',
+            paper: '#FFFFFF',
+        },
+        text: {
+            primary: '#1E2447',
+            secondary: '#5E668E',
+        },
+    },
+    shape: {
+        borderRadius: 14,
+    },
+    typography: {
+        fontFamily: 'Montserrat, sans-serif',
+        button: {
+            fontWeight: 700,
+            textTransform: 'none',
+        },
+    },
+    components: {
+        MuiPaper: {
+            styleOverrides: {
+                root: {
+                    borderRadius: 16,
+                    boxShadow: '0 8px 30px rgba(30, 36, 71, 0.08)',
+                    backgroundImage: 'none',
+                },
+            },
+        },
+        MuiButton: {
+            styleOverrides: {
+                root: {
+                    borderRadius: 12,
+                    padding: '10px 18px',
+                },
+            },
+        },
+        MuiTextField: {
+            defaultProps: {
+                variant: 'outlined',
+            },
+        },
+        MuiOutlinedInput: {
+            styleOverrides: {
+                root: {
+                    borderRadius: 12,
+                    backgroundColor: '#FFFFFF',
+                },
+            },
+        },
+        MuiChip: {
+            styleOverrides: {
+                root: {
+                    borderRadius: 10,
+                },
+            },
+        },
     },
 });
 

--- a/frontend/src/Views/DashboardView.jsx
+++ b/frontend/src/Views/DashboardView.jsx
@@ -4,13 +4,13 @@ import {useEffect, useState} from "react";
 import styled from "styled-components";
 import TopBar from "@/Components/TopBar/TopBar";
 import {useMediaQuery} from "@/Hooks/useMediaQuery";
-import ShoppingListsAPI from "@/API/ShoppingListsAPI";
 
 
 const Container = styled.div`
-    width: calc(100vw - 250px);
+    width: calc(100vw - 280px);
     height: 100vh;
-    background-color: #F3F3F3;
+    background: radial-gradient(circle at top right, #eef2ff 0%, #f8faff 45%, #f4f7ff 100%);
+    transition: width 0.2s ease-in;
 
     @media (max-width: 768px) {
         width: 100vw;
@@ -20,14 +20,21 @@ const Container = styled.div`
 
 const Flex = styled.div`
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-start;
     align-items: center;
     flex-direction: row;
+    background-color: #f4f7ff;
 `;
 
 const OutletContainer = styled.div`
   width: 100%;
   overflow: auto;
+  padding: 20px;
+  box-sizing: border-box;
+
+  @media (max-width: 768px) {
+      padding: 14px;
+  }
 `;
 
 const DashboardView = () => {


### PR DESCRIPTION
### Motivation
- Refresh the dashboard UI to a more modern, app-like appearance while preserving existing functionality and routes.
- Keep existing MUI components but alter their visual character so the app does not look like default Material Design.
- Improve layout spacing and mobile/desktop ergonomics for the main shell and navigation.

### Description
- Extended the global MUI theme (`frontend/src/Theme/theme.js`) with a new palette, typography, shape and component overrides for `MuiPaper`, `MuiButton`, `MuiOutlinedInput`, `MuiChip` to produce a softer, custom look.
- Reworked the main shell (`frontend/src/Views/DashboardView.jsx`) to adjust sidebar width, add a radial background, padding and content container spacing without changing behavior.
- Restyled the sidebar (`frontend/src/Components/Navigation/Navigation.jsx`) to use a gradient background, updated sizing, mini-action bar and mobile spacing; added subtle shadows and blur effects.
- Updated `NavItem` and `MiniNavItem` (`frontend/src/Components/NavItem/NavItem.jsx`, `frontend/src/Components/MiniNavItem/MiniNavItem.jsx`) to new hover/active styles, improved spacing and colors.
- Reworked the top bar (`frontend/src/Components/TopBar/TopBar.jsx`) for a taller, glass-like header with separate mobile/desktop layout while keeping the same actions (menu, scanner).
- Small global UI tweaks in `frontend/src/App/GlobalStyles/index.scss` (body background, text color, scrollbar styling).
- All changes are visual only; no business logic, routing or API behavior was modified.

### Testing
- Ran `npm --prefix frontend run build` and the production build completed successfully (build artifacts created and ready to deploy).
- The build produced existing ESLint warnings unrelated to these visual changes; no new test failures were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1cf1bed083238d2e700740336885)